### PR TITLE
VmxEnable and DebugConsent are now set in Kconfig in upstream cannonlake

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Building coreboot for System76 hardware
 sudo apt-get install git build-essential gnat flex bison libncurses5-dev wget zlib1g-dev nasm uuid-dev ccache
 
 # Build cross toolchain
-make CPUS=(nproc) crossgcc-i386 crossgcc-x64
+make CPUS=$(nproc) crossgcc-i386 crossgcc-x64
 
 # Set up the configuration and rebuild
 ./system76/build.sh galp3-b

--- a/src/mainboard/system76/whl-u/devicetree.cb
+++ b/src/mainboard/system76/whl-u/devicetree.cb
@@ -30,9 +30,9 @@ chip soc/intel/cannonlake
 
 # FSP Memory (soc/intel/cannonlake/romstage/fsp_params.c)
 	register "SaGv" = "SaGv_Enabled"
-	register "VmxEnable" = "1"
+	#register "VmxEnable" = "1"
 	#register "enable_c6dram" = "1"
-	register "DebugConsent" = "DebugConsent_Disabled"
+	#register "DebugConsent" = "DebugConsent_Disabled"
 
 # FSP Silicon (soc/intel/cannonlake/fsp_params.c)
 	# SATA


### PR DESCRIPTION
I've not yet flashed the result to my darp5 yet, but it builds now (again).