### PR TITLE
mainboard/system76: Fix compiling other boards on 4.12

### DIFF
--- a/src/mainboard/system76/cfl-h/devicetree.cb
+++ b/src/mainboard/system76/cfl-h/devicetree.cb
@@ -146,7 +146,7 @@ chip soc/intel/cannonlake
 	register "tcc_offset" = "2"
 
 	# Serial IRQ Continuous
-	register "SerialIrqConfigSirqMode" = "1"
+	register "serirq_mode" = "SERIRQ_CONTINUOUS"
 
 # LPC (soc/intel/cannonlake/lpc.c)
 	# LPC configuration from lspci -s 1f.0 -xxx

--- a/src/mainboard/system76/cfl-h/dsdt.asl
+++ b/src/mainboard/system76/cfl-h/dsdt.asl
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  */
 
-#include <arch/acpi.h>
+#include <acpi/acpi.h>
 DefinitionBlock(
 	"dsdt.aml",
 	"DSDT",

--- a/src/mainboard/system76/cml-u/devicetree.cb
+++ b/src/mainboard/system76/cml-u/devicetree.cb
@@ -144,7 +144,7 @@ chip soc/intel/cannonlake
 	register "tcc_offset" = "12"
 
 	# Serial IRQ Continuous
-	register "SerialIrqConfigSirqMode" = "1"
+	register "serirq_mode" = "SERIRQ_CONTINUOUS"
 
 # LPC (soc/intel/cannonlake/lpc.c)
 	# LPC configuration from lspci -s 1f.0 -xxx

--- a/src/mainboard/system76/cml-u/dsdt.asl
+++ b/src/mainboard/system76/cml-u/dsdt.asl
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  */
 
-#include <arch/acpi.h>
+#include <acpi/acpi.h>
 DefinitionBlock(
 	"dsdt.aml",
 	"DSDT",

--- a/src/mainboard/system76/cml-u/ramstage.c
+++ b/src/mainboard/system76/cml-u/ramstage.c
@@ -14,8 +14,8 @@
  */
 
 #include <string.h>
-#include <arch/acpi.h>
-#include <arch/acpigen.h>
+#include <acpi/acpi.h>
+#include <acpi/acpigen.h>
 #include <arch/io.h>
 #include <console/console.h>
 #include <device/device.h>
@@ -194,14 +194,14 @@ static void pcie_hotplug_generator(int port_number)
 	acpigen_pop_len();
 }
 
-static void fill_ssdt(struct device *device) {
+static void fill_ssdt(const struct device *device) {
 	printk(BIOS_INFO, "system76: fill_ssdt\n");
 	pcie_hotplug_generator(CONFIG_MAX_ROOT_PORTS);
 }
 
 static void mainboard_enable(struct device *dev) {
 	dev->ops->init = mainboard_init;
-	dev->ops->acpi_fill_ssdt_generator = fill_ssdt;
+	dev->ops->acpi_fill_ssdt = fill_ssdt;
 
 	// Configure pad for DisplayPort
 	uint32_t config = 0x44000200;

--- a/src/mainboard/system76/kbl-u/dsdt.asl
+++ b/src/mainboard/system76/kbl-u/dsdt.asl
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  */
 
-#include <arch/acpi.h>
+#include <acpi/acpi.h>
 DefinitionBlock(
 	"dsdt.aml",
 	"DSDT",

--- a/src/mainboard/system76/thelio-b1/devicetree.cb
+++ b/src/mainboard/system76/thelio-b1/devicetree.cb
@@ -144,7 +144,7 @@ chip soc/intel/cannonlake
     register "tcc_offset" = "12"
 
     # Serial IRQ Continuous
-    register "SerialIrqConfigSirqMode" = "1"
+    register "serirq_mode" = "SERIRQ_CONTINUOUS"
 
 # LPC (soc/intel/cannonlake/lpc.c)
     # LPC configuration from lspci -xxx

--- a/src/mainboard/system76/thelio-b1/dsdt.asl
+++ b/src/mainboard/system76/thelio-b1/dsdt.asl
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  */
 
-#include <arch/acpi.h>
+#include <acpi/acpi.h>
 DefinitionBlock(
 	"dsdt.aml",
 	"DSDT",

--- a/src/mainboard/system76/whl-u/devicetree.cb
+++ b/src/mainboard/system76/whl-u/devicetree.cb
@@ -144,7 +144,7 @@ chip soc/intel/cannonlake
 	register "tcc_offset" = "12"
 
 	# Serial IRQ Continuous
-	register "SerialIrqConfigSirqMode" = "1"
+	register "serirq_mode" = "SERIRQ_CONTINUOUS"
 
 # LPC (soc/intel/cannonlake/lpc.c)
 	# LPC configuration from lspci -s 1f.0 -xxx

--- a/src/mainboard/system76/whl-u/dsdt.asl
+++ b/src/mainboard/system76/whl-u/dsdt.asl
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  */
 
-#include <arch/acpi.h>
+#include <acpi/acpi.h>
 DefinitionBlock(
 	"dsdt.aml",
 	"DSDT",

--- a/src/mainboard/system76/whl-u/ramstage.c
+++ b/src/mainboard/system76/whl-u/ramstage.c
@@ -14,8 +14,8 @@
  */
 
 #include <string.h>
-#include <arch/acpi.h>
-#include <arch/acpigen.h>
+#include <acpi/acpi.h>
+#include <acpi/acpigen.h>
 #include <arch/io.h>
 #include <console/console.h>
 #include <device/device.h>
@@ -194,14 +194,14 @@ static void pcie_hotplug_generator(int port_number)
 	acpigen_pop_len();
 }
 
-static void fill_ssdt(struct device *device) {
+static void fill_ssdt(const struct device *device) {
 	printk(BIOS_INFO, "system76: fill_ssdt\n");
 	pcie_hotplug_generator(CONFIG_MAX_ROOT_PORTS);
 }
 
 static void mainboard_enable(struct device *dev) {
 	dev->ops->init = mainboard_init;
-	dev->ops->acpi_fill_ssdt_generator = fill_ssdt;
+	dev->ops->acpi_fill_ssdt = fill_ssdt;
 
 	// Configure pad for DisplayPort
 	uint32_t config = 0x44000200;


### PR DESCRIPTION
Fixes building on darp5, darp6, galp3-c, and galp4.
thelio-b1 and kbl-u updated for consistency.