### PR TITLE
mb/system76: Remove FSP_M_XIP

### DIFF
--- a/src/mainboard/system76/addw2/Kconfig
+++ b/src/mainboard/system76/addw2/Kconfig
@@ -25,7 +25,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SOC_INTEL_COMMON_BLOCK_HDA_VERB
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
-	select TPM_RDRESP_NEED_DELAY	
+	select TPM_RDRESP_NEED_DELAY
 	select USE_LEGACY_8254_TIMER # Fix failure to boot GRUB
 
 config MAINBOARD_DIR
@@ -87,10 +87,6 @@ config VGA_BIOS_FILE
 config VGA_BIOS_ID
 	string
 	default "8086,9bc4"
-
-config FSP_M_XIP
-	bool
-	default y
 
 config POST_DEVICE
 	bool

--- a/src/mainboard/system76/cml-u/Kconfig
+++ b/src/mainboard/system76/cml-u/Kconfig
@@ -23,7 +23,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SOC_INTEL_COMMON_BLOCK_HDA_VERB
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
-	select TPM_RDRESP_NEED_DELAY	
+	select TPM_RDRESP_NEED_DELAY
 	select USE_OPTION_TABLE
 	select USE_LEGACY_8254_TIMER # Fix failure to boot GRUB
 
@@ -93,10 +93,6 @@ config VGA_BIOS_ID
 config PXE_ROM_ID
 	string
 	default "10ec,8168"
-
-config FSP_M_XIP
-	bool
-	default y
 
 config POST_DEVICE
 	bool

--- a/src/mainboard/system76/gaze14/Kconfig
+++ b/src/mainboard/system76/gaze14/Kconfig
@@ -22,7 +22,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SOC_INTEL_COMMON_BLOCK_HDA_VERB
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
-	select TPM_RDRESP_NEED_DELAY	
+	select TPM_RDRESP_NEED_DELAY
 	select USE_LEGACY_8254_TIMER # Fix failure to boot GRUB
 
 config MAINBOARD_DIR
@@ -90,10 +90,6 @@ config DIMM_SPD_SIZE
 # config VGA_BIOS_ID
 # 	string
 # 	default "8086,3ea0"
-
-config FSP_M_XIP
-	bool
-	default y
 
 config POST_DEVICE
 	bool

--- a/src/mainboard/system76/gaze15/Kconfig
+++ b/src/mainboard/system76/gaze15/Kconfig
@@ -22,7 +22,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SOC_INTEL_COMMON_BLOCK_HDA_VERB
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
-	select TPM_RDRESP_NEED_DELAY	
+	select TPM_RDRESP_NEED_DELAY
 	select USE_LEGACY_8254_TIMER # Fix failure to boot GRUB
 
 config MAINBOARD_DIR
@@ -84,10 +84,6 @@ config VGA_BIOS_FILE
 config VGA_BIOS_ID
 	string
 	default "8086,9bc4"
-
-config FSP_M_XIP
-	bool
-	default y
 
 config POST_DEVICE
 	bool

--- a/src/mainboard/system76/kbl-u/Kconfig
+++ b/src/mainboard/system76/kbl-u/Kconfig
@@ -20,7 +20,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SOC_INTEL_KABYLAKE
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
-	select TPM_RDRESP_NEED_DELAY	
+	select TPM_RDRESP_NEED_DELAY
 	select USE_OPTION_TABLE
 	select USE_LEGACY_8254_TIMER # Fix failure to boot GRUB
 
@@ -91,10 +91,6 @@ config VGA_BIOS_ID
 config PXE_ROM_ID
 	string
 	default "10ec,8168"
-
-config FSP_M_XIP
-	bool
-	default y
 
 config POST_DEVICE
 	bool

--- a/src/mainboard/system76/lemp9/Kconfig
+++ b/src/mainboard/system76/lemp9/Kconfig
@@ -19,7 +19,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SOC_INTEL_COMMON_BLOCK_HDA_VERB
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
-	select TPM_RDRESP_NEED_DELAY	
+	select TPM_RDRESP_NEED_DELAY
 	select USE_LEGACY_8254_TIMER # Fix failure to boot GRUB
 
 config MAINBOARD_DIR
@@ -81,10 +81,6 @@ config VGA_BIOS_FILE
 config VGA_BIOS_ID
 	string
 	default "8086,9b41"
-
-config FSP_M_XIP
-	bool
-	default y
 
 config POST_DEVICE
 	bool

--- a/src/mainboard/system76/oryp6/Kconfig
+++ b/src/mainboard/system76/oryp6/Kconfig
@@ -24,7 +24,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SOC_INTEL_COMMON_BLOCK_HDA_VERB
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
-	select TPM_RDRESP_NEED_DELAY	
+	select TPM_RDRESP_NEED_DELAY
 	select USE_LEGACY_8254_TIMER # Fix failure to boot GRUB
 
 config MAINBOARD_DIR
@@ -86,10 +86,6 @@ config VGA_BIOS_FILE
 config VGA_BIOS_ID
 	string
 	default "8086,9bc4"
-
-config FSP_M_XIP
-	bool
-	default y
 
 config POST_DEVICE
 	bool

--- a/src/mainboard/system76/thelio-b1/Kconfig
+++ b/src/mainboard/system76/thelio-b1/Kconfig
@@ -74,10 +74,6 @@ config PXE_ROM_ID
 	string
 	default "8086,1539"
 
-config FSP_M_XIP
-	bool
-	default y
-
 config POST_DEVICE
 	bool
 	default n

--- a/src/mainboard/system76/whl-u/Kconfig
+++ b/src/mainboard/system76/whl-u/Kconfig
@@ -94,10 +94,6 @@ config PXE_ROM_ID
 	string
 	default "10ec,8168"
 
-config FSP_M_XIP
-	bool
-	default y
-
 config POST_DEVICE
 	bool
 	default n


### PR DESCRIPTION
`FSP_M_XIP` is already selected by the soc.

Ref: 48833363daef0 ("mb/system76/lemp9: drop FSP_M_XIP")