### PR TITLE
Adding USE_LEGACY_8254_TIMER to galp5 and lemp10 Kconfig

### DIFF
--- a/src/mainboard/system76/galp5/Kconfig
+++ b/src/mainboard/system76/galp5/Kconfig
@@ -24,6 +24,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
 	select TPM_RDRESP_NEED_DELAY
+	select USE_LEGACY_8254_TIMER # Fix failure to boot XEN
 
 config MAINBOARD_DIR
 	string

--- a/src/mainboard/system76/lemp10/Kconfig
+++ b/src/mainboard/system76/lemp10/Kconfig
@@ -23,6 +23,7 @@ config BOARD_SPECIFIC_OPTIONS
 	select SPD_READ_BY_WORD
 	select SYSTEM_TYPE_LAPTOP
 	select TPM_RDRESP_NEED_DELAY
+	select USE_LEGACY_8254_TIMER # Fix failure to boot XEN
 
 config MAINBOARD_DIR
 	string


### PR DESCRIPTION
Should fix issue of Xen not booting #41 