### PR TITLE
Update devicetrees based on upstream

### DIFF
--- a/src/mainboard/system76/addw1/devicetree.cb
+++ b/src/mainboard/system76/addw1/devicetree.cb
@@ -1,5 +1,4 @@
 chip soc/intel/cannonlake
-	# Lock Down
 	register "common_soc_config" = "{
 		.chipset_lockdown = CHIPSET_LOCKDOWN_COREBOOT,
 		// Touchpad I2C bus
@@ -10,22 +9,10 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
-		// /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
 		.tdp_pl1_override = 45,
-		// /sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw
 		.tdp_pl2_override = 90,
 	}"
 
@@ -40,188 +27,29 @@ chip soc/intel/cannonlake
 	# Serial I/O
 	register "SerialIoDevMode" = "{
 		[PchSerialIoIndexI2C0] = PchSerialIoPci, // Touchpad I2C bus
-		[PchSerialIoIndexI2C1] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C2] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C3] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C4] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C5] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI0] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI1] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI2] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART0] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART1] = PchSerialIoDisabled,
 		[PchSerialIoIndexUART2] = PchSerialIoPci, // Debug console
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "1" # HDD (SATA0B)
-	register "SataPortsEnable[1]" = "1" # SSD1 (SATA1A)
-	register "SataPortsEnable[2]" = "0"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "0"
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "0"
-	register "PchHdaAudioLinkDmic1" = "0"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
-	register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C
-	register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 2
-	register "usb2_ports[3]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 audio
-	register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 back
-	register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Per-Key RGB keyboard
-	register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)" # Camera
-	register "usb2_ports[9]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 right
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
-	register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 audio
-	register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 back
-	register "usb3_ports[6]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
-	register "PcieClkSrcUsage[8]" = "0x40"
-
-	# PCI Express root port #9 x4, Clock 9 (SSD1)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[9]" = "8"
-
-	# PCI Express root port #14 x1, Clock 5 (GLAN)
-	register "PcieRpEnable[13]" = "1"
-	register "PcieRpLtrEnable[13]" = "1"
-	register "PcieClkSrcUsage[5]" = "13"
-
-	# PCI Express root port #15 x1, Clock 7 (Card Reader)
-	register "PcieRpEnable[14]" = "1"
-	register "PcieRpLtrEnable[14]" = "1"
-	register "PcieClkSrcUsage[7]" = "14"
-
-	# PCI Express root port #16 x1, Clock 6 (WLAN)
-	register "PcieRpEnable[15]" = "1"
-	register "PcieRpLtrEnable[15]" = "1"
-	register "PcieClkSrcUsage[6]" = "15"
-
-	# PCI Express root port #17 x4, Clock 0 (Thunderbolt)
-	register "PcieRpEnable[16]" = "1"
-	register "PcieRpLtrEnable[16]" = "1"
-	register "PcieRpHotPlug[16]" = "1"
-	register "PcieClkSrcUsage[0]" = "16"
-
-	# PCI Express root port #21 x4, Clock 10 (SSD2)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[10]" = "20"
-
-    # Set all clocks sources to the same clock request
-	register "PcieClkSrcClkReq[0]" = "0"
-	register "PcieClkSrcClkReq[1]" = "1"
-	register "PcieClkSrcClkReq[2]" = "2"
-	register "PcieClkSrcClkReq[3]" = "3"
-	register "PcieClkSrcClkReq[4]" = "4"
-	register "PcieClkSrcClkReq[5]" = "5"
-	register "PcieClkSrcClkReq[6]" = "6"
-	register "PcieClkSrcClkReq[7]" = "7"
-	register "PcieClkSrcClkReq[8]" = "8"
-	register "PcieClkSrcClkReq[9]" = "9"
-	register "PcieClkSrcClkReq[10]" = "10"
-	register "PcieClkSrcClkReq[11]" = "11"
-	register "PcieClkSrcClkReq[12]" = "12"
-	register "PcieClkSrcClkReq[13]" = "13"
-	register "PcieClkSrcClkReq[14]" = "14"
-	register "PcieClkSrcClkReq[15]" = "15"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 11:10
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS3MinAssert" = "3" # 50ms
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 5:4
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS4MinAssert" = "1" # 1s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 19:18
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpSusMinAssert" = "4" # 4s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 17:16
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpAMinAssert" = "4" # 2s
 
 	# Thermal
-	# rdmsr --bitfield 31:24 --decimal 0x1A2
 	register "tcc_offset" = "8"
 
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Disable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
 
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_K"
 	register "gpe0_dw1" = "PMC_GPP_G"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -234,20 +62,45 @@ chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x65e1 inherit
 		device pci 00.0 on  end # Host Bridge
-		device pci 01.0 on  end # GPU Port
-		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 01.0 on      # GPU Port
+			# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
+			register "PcieClkSrcUsage[8]" = "0x40"
+			register "PcieClkSrcClkReq[8]" = "8"
+		end
+		device pci 02.0 on end  # Integrated Graphics Device
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
+			register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C
+			register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 2
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 audio
+			register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 back
+			register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Per-Key RGB keyboard
+			register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)" # Camera
+			register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 right
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
+			register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 audio
+			register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 back
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Shared SRAM
-		#chip drivers/intel/wifi
-		#	register "wake" = "PME_B0_EN_BIT"
-			device pci 14.3 on  end # CNVi wifi
-		#end
+		device pci 14.3 on      # CNVi wifi
+			#chip drivers/intel/wifi
+			#	register "wake" = "PME_B0_EN_BIT"
+			#end
+		end
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on
 			chip drivers/i2c/hid
@@ -268,16 +121,33 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[0]" = "1" # HDD (SATA0B)
+			register "SataPortsEnable[1]" = "1" # SSD1 (SATA1A)
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
 		device pci 1a.0 off end # eMMC
-		device pci 1b.0 on  end # PCI Express Port 17
+		device pci 1b.0 on      # PCI Express Port 17
+			# PCI Express root port #17 x4, Clock 0 (Thunderbolt)
+			register "PcieRpEnable[16]" = "1"
+			register "PcieRpLtrEnable[16]" = "1"
+			register "PcieRpHotPlug[16]" = "1"
+			register "PcieClkSrcUsage[0]" = "16"
+			register "PcieClkSrcClkReq[0]" = "0"
+		end
 		device pci 1b.1 off end # PCI Express Port 18
 		device pci 1b.2 off end # PCI Express Port 19
 		device pci 1b.3 off end # PCI Express Port 20
-		device pci 1b.4 on  end # PCI Express Port 21
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express root port #21 x4, Clock 10 (SSD2)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[10]" = "20"
+			register "PcieClkSrcClkReq[10]" = "10"
+			register "PcieRpSlotImplemented[20]" = "1"
+		end
 		device pci 1b.5 off end # PCI Express Port 22
 		device pci 1b.6 off end # PCI Express Port 23
 		device pci 1b.7 off end # PCI Express Port 24
@@ -289,32 +159,66 @@ chip soc/intel/cannonlake
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express root port #9 x4, Clock 9 (SSD1)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[9]" = "8"
+			register "PcieClkSrcClkReq[9]" = "9"
+			register "PcieRpSlotImplemented[8]" = "1"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
 		device pci 1d.4 off end # PCI Express Port 13
-		device pci 1d.5 on  end # PCI Express Port 14
-		device pci 1d.6 on  end # PCI Express Port 15
-		device pci 1d.7 on  end # PCI Express Port 16
+		device pci 1d.5 on      # PCI Express Port 14
+			# PCI Express root port #14 x1, Clock 5 (GLAN)
+			register "PcieRpEnable[13]" = "1"
+			register "PcieRpLtrEnable[13]" = "1"
+			register "PcieClkSrcUsage[5]" = "13"
+			register "PcieClkSrcClkReq[5]" = "5"
+			register "PcieRpSlotImplemented[13]" = "1"
+		end
+		device pci 1d.6 on      # PCI Express Port 15
+			# PCI Express root port #15 x1, Clock 7 (Card Reader)
+			register "PcieRpEnable[14]" = "1"
+			register "PcieRpLtrEnable[14]" = "1"
+			register "PcieClkSrcUsage[7]" = "14"
+			register "PcieClkSrcClkReq[7]" = "7"
+			register "PcieRpSlotImplemented[14]" = "1"
+		end
+		device pci 1d.7 on      # PCI Express Port 16
+			# PCI Express root port #16 x1, Clock 6 (WLAN)
+			register "PcieRpEnable[15]" = "1"
+			register "PcieRpLtrEnable[15]" = "1"
+			register "PcieClkSrcUsage[6]" = "15"
+			register "PcieClkSrcClkReq[6]" = "6"
+			register "PcieRpSlotImplemented[15]" = "1"
+		end
 		device pci 1e.0 off end # UART #0
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
 		device pci 1f.0 on # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
-		device pci 1f.4 on
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+		end
+		device pci 1f.4 on      # SMBus
 			chip drivers/i2c/tas5825m
 				register "id" = "0"
 				device i2c 4e on end # (8bit address: 0x9c)
-			end # tas5825m
-		end # SMBus
+			end
+		end
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE
 	end

--- a/src/mainboard/system76/addw2/devicetree.cb
+++ b/src/mainboard/system76/addw2/devicetree.cb
@@ -1,5 +1,4 @@
 chip soc/intel/cannonlake
-	# Lock Down
 	register "common_soc_config" = "{
 		.chipset_lockdown = CHIPSET_LOCKDOWN_COREBOOT,
 		// Touchpad I2C bus
@@ -10,22 +9,10 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
-		// /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
 		.tdp_pl1_override = 45,
-		// /sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw
 		.tdp_pl2_override = 90,
 	}"
 
@@ -40,188 +27,29 @@ chip soc/intel/cannonlake
 	# Serial I/O
 	register "SerialIoDevMode" = "{
 		[PchSerialIoIndexI2C0] = PchSerialIoPci, // Touchpad I2C bus
-		[PchSerialIoIndexI2C1] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C2] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C3] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C4] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C5] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI0] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI1] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI2] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART0] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART1] = PchSerialIoDisabled,
 		[PchSerialIoIndexUART2] = PchSerialIoPci, // Debug console
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "1" # HDD (SATA0B)
-	register "SataPortsEnable[1]" = "1" # SSD1 (SATA1A)
-	register "SataPortsEnable[2]" = "0"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "0"
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "0"
-	register "PchHdaAudioLinkDmic1" = "0"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
-	register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C
-	register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 2
-	register "usb2_ports[3]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 audio
-	register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 back
-	register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Per-Key RGB keyboard
-	register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)" # Camera
-	register "usb2_ports[9]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 right
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
-	register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 audio
-	register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 back
-	register "usb3_ports[6]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
-	register "PcieClkSrcUsage[8]" = "0x40"
-
-	# PCI Express root port #9 x4, Clock 9 (SSD1)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[9]" = "8"
-
-	# PCI Express root port #14 x1, Clock 5 (GLAN)
-	register "PcieRpEnable[13]" = "1"
-	register "PcieRpLtrEnable[13]" = "1"
-	register "PcieClkSrcUsage[5]" = "13"
-
-	# PCI Express root port #15 x1, Clock 7 (Card Reader)
-	register "PcieRpEnable[14]" = "1"
-	register "PcieRpLtrEnable[14]" = "1"
-	register "PcieClkSrcUsage[7]" = "14"
-
-	# PCI Express root port #16 x1, Clock 6 (WLAN)
-	register "PcieRpEnable[15]" = "1"
-	register "PcieRpLtrEnable[15]" = "1"
-	register "PcieClkSrcUsage[6]" = "15"
-
-	# PCI Express root port #17 x4, Clock 0 (Thunderbolt)
-	register "PcieRpEnable[16]" = "1"
-	register "PcieRpLtrEnable[16]" = "1"
-	register "PcieRpHotPlug[16]" = "1"
-	register "PcieClkSrcUsage[0]" = "16"
-
-	# PCI Express root port #21 x4, Clock 10 (SSD2)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[10]" = "20"
-
-    # Set all clocks sources to the same clock request
-	register "PcieClkSrcClkReq[0]" = "0"
-	register "PcieClkSrcClkReq[1]" = "1"
-	register "PcieClkSrcClkReq[2]" = "2"
-	register "PcieClkSrcClkReq[3]" = "3"
-	register "PcieClkSrcClkReq[4]" = "4"
-	register "PcieClkSrcClkReq[5]" = "5"
-	register "PcieClkSrcClkReq[6]" = "6"
-	register "PcieClkSrcClkReq[7]" = "7"
-	register "PcieClkSrcClkReq[8]" = "8"
-	register "PcieClkSrcClkReq[9]" = "9"
-	register "PcieClkSrcClkReq[10]" = "10"
-	register "PcieClkSrcClkReq[11]" = "11"
-	register "PcieClkSrcClkReq[12]" = "12"
-	register "PcieClkSrcClkReq[13]" = "13"
-	register "PcieClkSrcClkReq[14]" = "14"
-	register "PcieClkSrcClkReq[15]" = "15"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 11:10
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS3MinAssert" = "3" # 50ms
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 5:4
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS4MinAssert" = "1" # 1s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 19:18
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpSusMinAssert" = "4" # 4s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 17:16
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpAMinAssert" = "4" # 2s
 
 	# Thermal
-	# rdmsr --bitfield 31:24 --decimal 0x1A2
 	register "tcc_offset" = "8"
 
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Disable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
 
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_K"
 	register "gpe0_dw1" = "PMC_GPP_G"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -234,14 +62,38 @@ chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x65e1 inherit
 		device pci 00.0 on  end # Host Bridge
-		device pci 01.0 on  end # GPU Port
+		device pci 01.0 on      # GPU Port
+			# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
+			register "PcieClkSrcUsage[8]" = "0x40"
+			register "PcieClkSrcClkReq[8]" = "8"
+		end
 		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
+			register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C
+			register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 2
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 audio
+			register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 3.1 Gen 1 back
+			register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Per-Key RGB keyboard
+			register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)" # Camera
+			register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C and DisplayPort
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 right
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 2 TYPE-C (without TBT)
+			register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 audio
+			register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 Gen 1 back
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Shared SRAM
 		#chip drivers/intel/wifi
@@ -268,16 +120,32 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[0]" = "1" # HDD (SATA0B)
+			register "SataPortsEnable[1]" = "1" # SSD1 (SATA1A)
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
 		device pci 1a.0 off end # eMMC
-		device pci 1b.0 on  end # PCI Express Port 17
+		device pci 1b.0 on      # PCI Express Port 17
+			# PCI Express root port #17 x4, Clock 0 (Thunderbolt)
+			register "PcieRpEnable[16]" = "1"
+			register "PcieRpLtrEnable[16]" = "1"
+			register "PcieRpHotPlug[16]" = "1"
+			register "PcieClkSrcUsage[0]" = "16"
+			register "PcieClkSrcClkReq[0]" = "0"
+		end
 		device pci 1b.1 off end # PCI Express Port 18
 		device pci 1b.2 off end # PCI Express Port 19
 		device pci 1b.3 off end # PCI Express Port 20
-		device pci 1b.4 on  end # PCI Express Port 21
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express root port #21 x4, Clock 10 (SSD2)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[10]" = "20"
+			register "PcieClkSrcClkReq[10]" = "10"
+		end
 		device pci 1b.5 off end # PCI Express Port 22
 		device pci 1b.6 off end # PCI Express Port 23
 		device pci 1b.7 off end # PCI Express Port 24
@@ -289,26 +157,56 @@ chip soc/intel/cannonlake
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express root port #9 x4, Clock 9 (SSD1)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[9]" = "8"
+			register "PcieClkSrcClkReq[9]" = "9"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
 		device pci 1d.4 off end # PCI Express Port 13
-		device pci 1d.5 on  end # PCI Express Port 14
-		device pci 1d.6 on  end # PCI Express Port 15
-		device pci 1d.7 on  end # PCI Express Port 16
+		device pci 1d.5 on      # PCI Express Port 14
+			# PCI Express root port #14 x1, Clock 5 (GLAN)
+			register "PcieRpEnable[13]" = "1"
+			register "PcieRpLtrEnable[13]" = "1"
+			register "PcieClkSrcUsage[5]" = "13"
+			register "PcieClkSrcClkReq[5]" = "5"
+		end
+		device pci 1d.6 on      # PCI Express Port 15
+			# PCI Express root port #15 x1, Clock 7 (Card Reader)
+			register "PcieRpEnable[14]" = "1"
+			register "PcieRpLtrEnable[14]" = "1"
+			register "PcieClkSrcUsage[7]" = "14"
+			register "PcieClkSrcClkReq[7]" = "7"
+		end
+		device pci 1d.7 on      # PCI Express Port 16
+			# PCI Express root port #16 x1, Clock 6 (WLAN)
+			register "PcieRpEnable[15]" = "1"
+			register "PcieRpLtrEnable[15]" = "1"
+			register "PcieClkSrcUsage[6]" = "15"
+			register "PcieClkSrcClkReq[6]" = "6"
+		end
 		device pci 1e.0 off end # UART #0
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
 		device pci 1f.0 on # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+		end
 		device pci 1f.4 on
 			chip drivers/i2c/tas5825m
 				register "id" = "0"

--- a/src/mainboard/system76/bonw14/devicetree.cb
+++ b/src/mainboard/system76/bonw14/devicetree.cb
@@ -1,5 +1,4 @@
 chip soc/intel/cannonlake
-	# Lock Down
 	register "common_soc_config" = "{
 		.chipset_lockdown = CHIPSET_LOCKDOWN_COREBOOT,
 		// Touchpad I2C bus
@@ -10,22 +9,10 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
-		// /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
 		.tdp_pl1_override = 125,
-		// /sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw
 		.tdp_pl2_override = 160,
 	}"
 
@@ -42,174 +29,23 @@ chip soc/intel/cannonlake
 		[PchSerialIoIndexUART2] = PchSerialIoPci, // Debug console
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "0"
-	register "SataPortsEnable[1]" = "1" # SATA1A (SSD)
-	register "SataPortsEnable[2]" = "0"
-	register "SataPortsEnable[3]" = "1" # SATA3 (M.2_SATA3)
-	register "SataPortsEnable[4]" = "1" # SATA4 (SSD2)
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "0"
-	register "PchHdaAudioLinkDmic1" = "0"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_2
-	register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_1
-	register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_4
-	register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_3
-	register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # Per-key RGB
-	register "usb2_ports[5]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB Type-C
-	register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # XFI
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
-	register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)" # Light guide
-	register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3_2
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # ANX7440
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3_4
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3_3
-	register "usb3_ports[4]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[5]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[6]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Graphics #0 x16, Clock 7 (NVIDIA GPU)
-	register "PcieClkSrcUsage[7]" = "0x40"
-
-	# PCI Express root port #1 x4, Clock 6 (Thunderbolt)
-	register "PcieRpEnable[0]" = "1"
-	register "PcieRpLtrEnable[0]" = "1"
-	register "PcieRpHotPlug[0]" = "1"
-	register "PcieClkSrcUsage[6]" = "PCIE_CLK_RP0" # 0 is converted to PCIE_CLK_NOTUSED
-
-	# PCI Express root port #5 x4, Clock 10 (USB 3.2)
-	register "PcieRpEnable[4]" = "1"
-	register "PcieRpLtrEnable[4]" = "1"
-	register "PcieClkSrcUsage[10]" = "4"
-
-	# PCI Express root port #9 x4, Clock 8 (SSD)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[8]" = "8"
-
-	# PCI Express root port #13 x1, Clock 0 (WLAN)
-	register "PcieRpEnable[12]" = "1"
-	register "PcieRpLtrEnable[12]" = "1"
-	register "PcieClkSrcUsage[0]" = "12"
-
-	# PCI Express root port #14 x1, Clock 1 (GLAN)
-	register "PcieRpEnable[13]" = "1"
-	register "PcieRpLtrEnable[13]" = "1"
-	register "PcieClkSrcUsage[1]" = "13"
-
-	# PCI Express root port #15 x1, Clock 4 (Card Reader)
-	register "PcieRpEnable[14]" = "1"
-	register "PcieRpLtrEnable[14]" = "1"
-	register "PcieClkSrcUsage[4]" = "14"
-
-	# PCI Express root port #17 x4, Clock 14 (SSD2)
-	register "PcieRpEnable[16]" = "1"
-	register "PcieRpLtrEnable[16]" = "1"
-	register "PcieClkSrcUsage[14]" = "16"
-
-	# PCI Express root port #21 x4, Clock 15 (SSD3)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[15]" = "20"
-
-    # Set all clocks sources to the same clock request
-	register "PcieClkSrcClkReq[0]" = "0"
-	register "PcieClkSrcClkReq[1]" = "1"
-	register "PcieClkSrcClkReq[2]" = "2"
-	register "PcieClkSrcClkReq[3]" = "3"
-	register "PcieClkSrcClkReq[4]" = "4"
-	register "PcieClkSrcClkReq[5]" = "5"
-	register "PcieClkSrcClkReq[6]" = "6"
-	register "PcieClkSrcClkReq[7]" = "7"
-	register "PcieClkSrcClkReq[8]" = "8"
-	register "PcieClkSrcClkReq[9]" = "9"
-	register "PcieClkSrcClkReq[10]" = "10"
-	register "PcieClkSrcClkReq[11]" = "11"
-	register "PcieClkSrcClkReq[12]" = "12"
-	register "PcieClkSrcClkReq[13]" = "13"
-	register "PcieClkSrcClkReq[14]" = "14"
-	register "PcieClkSrcClkReq[15]" = "15"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 11:10
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS3MinAssert" = "3" # 50ms
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 5:4
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS4MinAssert" = "1" # 1s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 19:18
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpSusMinAssert" = "4" # 4s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 17:16
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpAMinAssert" = "4" # 2s
 
 	# Thermal
-	# rdmsr --bitfield 31:24 --decimal 0x1A2
 	register "tcc_offset" = "13"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
 
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_K"
 	register "gpe0_dw1" = "PMC_GPP_G"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -222,21 +58,45 @@ chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x7714 inherit
 		device pci 00.0 on  end # Host Bridge
-		device pci 01.0 on  end # GPU Port
-		#TODO: is this enough to disable iGPU?
-		device pci 02.0 off end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 01.0 on      # GPU Port
+			# PCI Express Graphics #0 x16, Clock 7 (NVIDIA GPU)
+			register "PcieClkSrcUsage[7]" = "0x40"
+			register "PcieClkSrcClkReq[7]" = "7"
+		end
+		device pci 02.0 off end # Integrated Graphics Device # TODO: is this enough to disable iGPU?
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_2
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_1
+			register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_4
+			register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)" # USB 3_3
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # Per-key RGB
+			register "usb2_ports[5]" = "USB2_PORT_TYPE_C(OC_SKIP)" # USB Type-C
+			register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # XFI
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
+			register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)" # Light guide
+			register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
+			register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3_2
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # ANX7440
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3_4
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3_3
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Shared SRAM
-		#chip drivers/intel/wifi
-		#	register "wake" = "PME_B0_EN_BIT"
-			device pci 14.3 on  end # CNVi wifi
-		#end
+		device pci 14.3 on      # CNVi wifi
+			#chip drivers/intel/wifi
+			#	register "wake" = "PME_B0_EN_BIT"
+			#end
+		end
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on
 			chip drivers/i2c/hid
@@ -257,57 +117,115 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[1]" = "1" # SATA1A (SSD)
+			register "SataPortsEnable[3]" = "1" # SATA3 (M.2_SATA3)
+			register "SataPortsEnable[4]" = "1" # SATA4 (SSD2)
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
 		device pci 1a.0 off end # eMMC
-		device pci 1b.0 on  end # PCI Express Port 17
+		device pci 1b.0 on      # PCI Express Port 17
+			# PCI Express root port #17 x4, Clock 14 (SSD2)
+			register "PcieRpEnable[16]" = "1"
+			register "PcieRpLtrEnable[16]" = "1"
+			register "PcieClkSrcUsage[14]" = "16"
+			register "PcieClkSrcClkReq[14]" = "14"
+		end
 		device pci 1b.1 off end # PCI Express Port 18
 		device pci 1b.2 off end # PCI Express Port 19
 		device pci 1b.3 off end # PCI Express Port 20
-		device pci 1b.4 on  end # PCI Express Port 21
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express root port #21 x4, Clock 15 (SSD3)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[15]" = "20"
+			register "PcieClkSrcClkReq[15]" = "15"
+		end
 		device pci 1b.5 off end # PCI Express Port 22
 		device pci 1b.6 off end # PCI Express Port 23
 		device pci 1b.7 off end # PCI Express Port 24
-		device pci 1c.0 on  end # PCI Express Port 1
+		device pci 1c.0 on      # PCI Express Port 1
+			# PCI Express root port #1 x4, Clock 6 (Thunderbolt)
+			register "PcieRpEnable[0]" = "1"
+			register "PcieRpLtrEnable[0]" = "1"
+			register "PcieRpHotPlug[0]" = "1"
+			register "PcieClkSrcUsage[6]" = "PCIE_CLK_RP0" # 0 is converted to PCIE_CLK_NOTUSED
+			register "PcieClkSrcClkReq[6]" = "6"
+		end
 		device pci 1c.1 off end # PCI Express Port 2
 		device pci 1c.2 off end # PCI Express Port 3
 		device pci 1c.3 off end # PCI Express Port 4
-		device pci 1c.4 on  end # PCI Express Port 5
+		device pci 1c.4 on      # PCI Express Port 5
+			# PCI Express root port #5 x4, Clock 10 (USB 3.2)
+			register "PcieRpEnable[4]" = "1"
+			register "PcieRpLtrEnable[4]" = "1"
+			register "PcieClkSrcUsage[10]" = "4"
+			register "PcieClkSrcClkReq[10]" = "10"
+		end
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express root port #9 x4, Clock 8 (SSD)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[8]" = "8"
+			register "PcieClkSrcClkReq[8]" = "8"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
-		device pci 1d.4 on  end # PCI Express Port 13
-		device pci 1d.5 on  end # PCI Express Port 14
-		device pci 1d.6 on  end # PCI Express Port 15
+		device pci 1d.4 on      # PCI Express Port 13
+			# PCI Express root port #13 x1, Clock 0 (WLAN)
+			register "PcieRpEnable[12]" = "1"
+			register "PcieRpLtrEnable[12]" = "1"
+			register "PcieClkSrcUsage[0]" = "12"
+		end
+		device pci 1d.5 on      # PCI Express Port 14
+			# PCI Express root port #14 x1, Clock 1 (GLAN)
+			register "PcieRpEnable[13]" = "1"
+			register "PcieRpLtrEnable[13]" = "1"
+			register "PcieClkSrcUsage[1]" = "13"
+			register "PcieClkSrcClkReq[1]" = "1"
+		end
+		device pci 1d.6 on      # PCI Express Port 15
+			# PCI Express root port #15 x1, Clock 4 (Card Reader)
+			register "PcieRpEnable[14]" = "1"
+			register "PcieRpLtrEnable[14]" = "1"
+			register "PcieClkSrcUsage[4]" = "14"
+			register "PcieClkSrcClkReq[4]" = "4"
+		end
 		device pci 1d.7 off end # PCI Express Port 16
 		device pci 1e.0 off end # UART #0
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
-		device pci 1f.0 on # LPC Interface
+		device pci 1f.0 on      # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
-		device pci 1f.4 on
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+		end
+		device pci 1f.4 on      # SMBus
 			chip drivers/i2c/tas5825m
 				register "id" = "0"
 				device i2c 4e on end # (8bit address: 0x9c)
-			end # tas5825m
+			end
 			chip drivers/i2c/tas5825m
 				register "id" = "1"
 				device i2c 4f on end # (8bit address: 0x9e)
-			end # tas5825m
-		end # SMBus
+			end
+		end
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE
 	end

--- a/src/mainboard/system76/cml-u/devicetree.cb
+++ b/src/mainboard/system76/cml-u/devicetree.cb
@@ -9,16 +9,6 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
@@ -40,107 +30,14 @@ chip soc/intel/cannonlake
 		[PchSerialIoIndexUART2] = PchSerialIoSkipInit, // LPSS UART
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "1"
-	register "SataPortsEnable[1]" = "0"
-	register "SataPortsEnable[2]" = "1"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "0"
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "1"
-	register "PchHdaAudioLinkDmic1" = "1"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"		# Type-A port 1
-	register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)"		# 3G / LTE
-	register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"	# Type-C port 3
-	register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)"		# USB Board port 4
-	register "usb2_ports[4]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[5]" = "USB2_PORT_EMPTY"			# Finger print
-	register "usb2_ports[6]" = "USB2_PORT_MAX(OC_SKIP)"		# Camera
-	register "usb2_ports[7]" = "USB2_PORT_EMPTY"			# T17, T18
-	register "usb2_ports[8]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)"		# Bluetooth
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[13]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"			# NC
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" 	# Type-A port 1
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# 4G
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# Type C port 3
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# USB Board port 4
-	register "usb3_ports[4]" = "USB3_PORT_EMPTY"				# Used by TBT
-	register "usb3_ports[5]" = "USB3_PORT_EMPTY"				# Used by TBT
-	register "usb3_ports[6]" = "USB3_PORT_EMPTY"				# NC
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"				# NC
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"				# NC
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"				# NC
-
-	# PCI Express Root port #5 x4, Clock 4 (TBT)
-	register "PcieRpEnable[4]" = "1"
-	register "PcieRpLtrEnable[4]" = "1"
-	register "PcieRpHotPlug[4]" = "1"
-	register "PcieClkSrcUsage[4]" = "4"
-	register "PcieClkSrcClkReq[4]" = "4"
-
-	# PCI Express Root port #9 x1, Clock 3 (LAN)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[3]" = "8"
-	register "PcieClkSrcClkReq[3]" = "3"
-
-	# PCI Express Root port #10 x1, Clock 2 (WLAN)
-	register "PcieRpEnable[9]" = "1"
-	register "PcieRpLtrEnable[9]" = "0"
-	register "PcieClkSrcUsage[2]" = "9"
-	register "PcieClkSrcClkReq[2]" = "2"
-
-	# PCI Express Root port #13 x4, Clock 5 (NVMe)
-	register "PcieRpEnable[12]" = "1"
-	register "PcieRpLtrEnable[12]" = "1"
-	register "PcieClkSrcUsage[5]" = "12"
-	register "PcieClkSrcClkReq[5]" = "5"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	register "PchPmSlpS3MinAssert" = "3"		# 50ms
-	register "PchPmSlpS4MinAssert" = "1"		# 1s
-	register "PchPmSlpSusMinAssert" = "2"		# 500ms
-	register "PchPmSlpAMinAssert" = "4"		# 2s
+	register "PchPmSlpS3MinAssert" = "3"	# 50ms
+	register "PchPmSlpS4MinAssert" = "1"	# 1s
+	register "PchPmSlpSusMinAssert" = "2"	# 500ms
+	register "PchPmSlpAMinAssert" = "4"	# 2s
 
 	# Thermal
 	register "tcc_offset" = "12"
@@ -148,34 +45,11 @@ chip soc/intel/cannonlake
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
 
-# Graphics (soc/intel/cannonlake/graphics.c)
-    register "gfx" = "GMA_STATIC_DISPLAYS(0)"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Enable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
-
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_C"
 	register "gpe0_dw1" = "PMC_GPP_D"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -187,18 +61,38 @@ chip soc/intel/cannonlake
 
 	device domain 0 on
 		device pci 00.0 on  end # Host Bridge
-		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 02.0 on      # Integrated Graphics Device
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
+		end
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"		# Type-A port 1
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)"		# 3G / LTE
+			register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"		# Type-C port 3
+			register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)"		# USB Board port 4
+			register "usb2_ports[6]" = "USB2_PORT_MAX(OC_SKIP)"		# Camera
+			register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)"		# Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# Type-A port 1
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# 4G
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# Type C port 3
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# USB Board port 4
+			register "usb3_ports[4]" = "USB3_PORT_EMPTY"			# Used by TBT
+			register "usb3_ports[5]" = "USB3_PORT_EMPTY"			# Used by TBT
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
-		#chip drivers/intel/wifi
-		#	register "wake" = "PME_B0_EN_BIT"
-			device pci 14.3 on  end # CNVi wifi
-		#end
+		device pci 14.3 on      # CNVi wifi
+			#chip drivers/intel/wifi
+			#	register "wake" = "PME_B0_EN_BIT"
+			#end
+		end
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on  end # I2C #0
 		device pci 15.1 off end # I2C #1
@@ -210,7 +104,10 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[0]" = "1"
+			register "SataPortsEnable[2]" = "1"
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
@@ -219,15 +116,40 @@ chip soc/intel/cannonlake
 		device pci 1c.1 off end # PCI Express Port 2
 		device pci 1c.2 off end # PCI Express Port 3
 		device pci 1c.3 off end # PCI Express Port 4
-		device pci 1c.4 on  end # PCI Express Port 5
+		device pci 1c.4 on      # PCI Express Port 5
+			# PCI Express Root port #5 x4, Clock 4 (TBT)
+			register "PcieRpEnable[4]" = "1"
+			register "PcieRpLtrEnable[4]" = "1"
+			register "PcieRpHotPlug[4]" = "1"
+			register "PcieClkSrcUsage[4]" = "4"
+			register "PcieClkSrcClkReq[4]" = "4"
+		end
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
-		device pci 1d.1 on  end # PCI Express Port 10
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express Root port #9 x1, Clock 3 (LAN)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[3]" = "8"
+			register "PcieClkSrcClkReq[3]" = "3"
+		end
+		device pci 1d.1 on      # PCI Express Port 10
+			# PCI Express Root port #10 x1, Clock 2 (WLAN)
+			register "PcieRpEnable[9]" = "1"
+			register "PcieRpLtrEnable[9]" = "0"
+			register "PcieClkSrcUsage[2]" = "9"
+			register "PcieClkSrcClkReq[2]" = "2"
+		end
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
-		device pci 1d.4 on  end # PCI Express Port 13
+		device pci 1d.4 on      # PCI Express Port 13
+			# PCI Express Root port #13 x4, Clock 5 (NVMe)
+			register "PcieRpEnable[12]" = "1"
+			register "PcieRpLtrEnable[12]" = "1"
+			register "PcieClkSrcUsage[5]" = "12"
+			register "PcieClkSrcClkReq[5]" = "5"
+		end
 		device pci 1d.5 off end # PCI Express Port 14
 		device pci 1d.6 off end # PCI Express Port 15
 		device pci 1d.7 off end # PCI Express Port 16
@@ -235,14 +157,22 @@ chip soc/intel/cannonlake
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
-		device pci 1f.0 on # LPC Interface
+		device pci 1f.0 on      # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+			register "PchHdaAudioLinkDmic0" = "1"
+			register "PchHdaAudioLinkDmic1" = "1"
+		end
 		device pci 1f.4 on  end # SMBus
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE

--- a/src/mainboard/system76/gaze14/devicetree.cb
+++ b/src/mainboard/system76/gaze14/devicetree.cb
@@ -1,5 +1,4 @@
 chip soc/intel/cannonlake
-	# Lock Down
 	register "common_soc_config" = "{
 		.chipset_lockdown = CHIPSET_LOCKDOWN_COREBOOT,
 		// Touchpad I2C bus
@@ -10,25 +9,10 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Enable s0ix
-	register "s0ix_enable" = "0"
-
-	# PM Timer Enabled
-	register "PmTimerDisabled" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
-		// /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
 		.tdp_pl1_override = 45,
-		// /sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw
 		.tdp_pl2_override = 90,
 	}"
 
@@ -47,184 +31,29 @@ chip soc/intel/cannonlake
 	register "SerialIoDevMode" = "{
 		[PchSerialIoIndexI2C0] = PchSerialIoPci, // Touchpad I2C bus
 		[PchSerialIoIndexI2C1] = PchSerialIoPci, // USB-C
-		[PchSerialIoIndexI2C2] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C3] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C4] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C5] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI0] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI1] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI2] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART0] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART1] = PchSerialIoDisabled,
 		[PchSerialIoIndexUART2] = PchSerialIoPci, // Debug console
 	}"
 
-	# SATA
-	register "SataMode" = "Sata_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "0"
-	register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
-	register "SataPortsEnable[2]" = "0"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "1" # HDD (SATA4)
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "1"
-	register "PchHdaAudioLinkDmic1" = "1"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB
-	register "SsicPortEnable" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right
-	register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
-	register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
-	register "usb2_ports[3]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[4]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 2 Left
-	register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # 3G/LTE
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
-	register "usb2_ports[8]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[9]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Right
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
-	register "usb3_ports[4]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[5]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC_SKIP)" # 3G/LTE
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
-	register "PcieClkSrcUsage[8]" = "0x40"
-
-	# PCI Express root port #9 x4, Clock 10 (SSD)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[10]" = "8"
-
-	# PCI Express root port #14 x1, Clock 6 (WLAN)
-	register "PcieRpEnable[13]" = "1"
-	register "PcieRpLtrEnable[13]" = "1"
-	register "PcieClkSrcUsage[6]" = "13"
-
-	# PCI Express root port #15 x1, Clock 5 (LAN)
-	register "PcieRpEnable[14]" = "1"
-	register "PcieRpLtrEnable[14]" = "1"
-	register "PcieClkSrcUsage[5]" = "14"
-
-	# PCI Express root port #21 x4, Clock 11 (SSD2)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[11]" = "20"
-
-    # Set all clocks sources to the same clock request
-	register "PcieClkSrcClkReq[0]" = "0"
-	register "PcieClkSrcClkReq[1]" = "1"
-	register "PcieClkSrcClkReq[2]" = "2"
-	register "PcieClkSrcClkReq[3]" = "3"
-	register "PcieClkSrcClkReq[4]" = "4"
-	register "PcieClkSrcClkReq[5]" = "5"
-	register "PcieClkSrcClkReq[6]" = "6"
-	register "PcieClkSrcClkReq[7]" = "7"
-	register "PcieClkSrcClkReq[8]" = "8"
-	register "PcieClkSrcClkReq[9]" = "9"
-	register "PcieClkSrcClkReq[10]" = "10"
-	register "PcieClkSrcClkReq[11]" = "11"
-	register "PcieClkSrcClkReq[12]" = "12"
-	register "PcieClkSrcClkReq[13]" = "13"
-	register "PcieClkSrcClkReq[14]" = "14"
-	register "PcieClkSrcClkReq[15]" = "15"
-
 	# Misc
-	register "Device4Enable" = "1"
-	register "HeciEnabled" = "0"
-	register "Heci3Enabled" = "0"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 11:10
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS3MinAssert" = "3" # 50ms
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 5:4
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS4MinAssert" = "1" # 1s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 19:18
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpSusMinAssert" = "4" # 4s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 17:16
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpAMinAssert" = "4" # 2s
 
 	# Thermal
-	# rdmsr --bitfield 31:24 --decimal 0x1A2
 	register "tcc_offset" = "8"
 
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
-
-# Graphics (soc/intel/cannonlake/graphics.c)
-    register "gfx" = "GMA_STATIC_DISPLAYS(0)"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Enable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
 
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_K"
 	register "gpe0_dw1" = "PMC_GPP_G"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -236,14 +65,37 @@ chip soc/intel/cannonlake
 
 	device domain 0 on
 		device pci 00.0 on  end # Host Bridge
-		device pci 01.0 on  end # GPU Port
-		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 01.0 on      # GPU Port
+			# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
+			register "PcieClkSrcUsage[8]" = "0x40"
+			register "PcieClkSrcClkReq[8]" = "8"
+		end
+		device pci 02.0 on      # Integrated Graphics Device
+			register "gfx" = "GMBA_DEFAULT_PANEL(0)"
+		end
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
+			register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
+			register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 2 Left
+			register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # 3G/LTE
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
+			register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Right
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
+			register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC_SKIP)" # 3G/LTE
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Shared SRAM
 		#chip drivers/intel/wifi
@@ -270,7 +122,10 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
+			register "SataPortsEnable[4]" = "1" # HDD (SATA4)
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
@@ -279,7 +134,13 @@ chip soc/intel/cannonlake
 		device pci 1b.1 off end # PCI Express Port 18
 		device pci 1b.2 off end # PCI Express Port 19
 		device pci 1b.3 off end # PCI Express Port 20
-		device pci 1b.4 on  end # PCI Express Port 21
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express root port #21 x4, Clock 11 (SSD2)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[11]" = "20"
+			register "PcieClkSrcClkReq[11]" = "11"
+		end
 		device pci 1b.5 off end # PCI Express Port 22
 		device pci 1b.6 off end # PCI Express Port 23
 		device pci 1b.7 off end # PCI Express Port 24
@@ -291,26 +152,52 @@ chip soc/intel/cannonlake
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express root port #9 x4, Clock 10 (SSD)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[10]" = "8"
+			register "PcieClkSrcClkReq[10]" = "10"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
 		device pci 1d.4 off end # PCI Express Port 13
-		device pci 1d.5 on  end # PCI Express Port 14
-		device pci 1d.6 on  end # PCI Express Port 15
+		device pci 1d.5 on      # PCI Express Port 14
+			# PCI Express root port #14 x1, Clock 6 (WLAN)
+			register "PcieRpEnable[13]" = "1"
+			register "PcieRpLtrEnable[13]" = "1"
+			register "PcieClkSrcUsage[6]" = "13"
+			register "PcieClkSrcClkReq[6]" = "6"
+		end
+		device pci 1d.6 on      # PCI Express Port 15
+			# PCI Express root port #15 x1, Clock 5 (LAN)
+			register "PcieRpEnable[14]" = "1"
+			register "PcieRpLtrEnable[14]" = "1"
+			register "PcieClkSrcUsage[5]" = "14"
+			register "PcieClkSrcClkReq[5]" = "5"
+		end
 		device pci 1d.7 off end # PCI Express Port 16
 		device pci 1e.0 off end # UART #0
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
 		device pci 1f.0 on # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+			register "PchHdaAudioLinkDmic0" = "1"
+			register "PchHdaAudioLinkDmic1" = "1"
+		end
 		device pci 1f.4 on  end # SMBus
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE

--- a/src/mainboard/system76/gaze15/devicetree.cb
+++ b/src/mainboard/system76/gaze15/devicetree.cb
@@ -1,5 +1,4 @@
 chip soc/intel/cannonlake
-	# Lock Down
 	register "common_soc_config" = "{
 		.chipset_lockdown = CHIPSET_LOCKDOWN_COREBOOT,
 		// Touchpad I2C bus
@@ -10,22 +9,10 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
-		// /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
 		.tdp_pl1_override = 45,
-		// /sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw
 		.tdp_pl2_override = 90,
 	}"
 
@@ -41,179 +28,29 @@ chip soc/intel/cannonlake
 	register "SerialIoDevMode" = "{
 		[PchSerialIoIndexI2C0] = PchSerialIoPci, // Touchpad I2C bus
 		[PchSerialIoIndexI2C1] = PchSerialIoPci, // USB-C
-		[PchSerialIoIndexI2C2] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C3] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C4] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C5] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI0] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI1] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI2] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART0] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART1] = PchSerialIoDisabled,
 		[PchSerialIoIndexUART2] = PchSerialIoPci, // Debug console
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "0"
-	register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
-	register "SataPortsEnable[2]" = "0"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "1" # HDD (SATA4)
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "1"
-	register "PchHdaAudioLinkDmic1" = "1"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right
-	register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
-	register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
-	register "usb2_ports[3]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[4]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 2 Left
-	register "usb2_ports[6]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
-	register "usb2_ports[8]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Right
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
-	register "usb3_ports[4]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[5]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[6]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
-	register "PcieClkSrcUsage[8]" = "0x40"
-
-	# PCI Express root port #9 x4, Clock 10 (SSD)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[10]" = "8"
-
-	# PCI Express root port #14 x1, Clock 6 (WLAN)
-	register "PcieRpEnable[13]" = "1"
-	register "PcieRpLtrEnable[13]" = "1"
-	register "PcieClkSrcUsage[6]" = "13"
-
-	# PCI Express root port #15 x1, Clock 5 (LAN)
-	register "PcieRpEnable[14]" = "1"
-	register "PcieRpLtrEnable[14]" = "1"
-	register "PcieClkSrcUsage[5]" = "14"
-
-	# PCI Express root port #21 x4, Clock 11 (SSD2)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[11]" = "20"
-
-    # Set all clocks sources to the same clock request
-	register "PcieClkSrcClkReq[0]" = "0"
-	register "PcieClkSrcClkReq[1]" = "1"
-	register "PcieClkSrcClkReq[2]" = "2"
-	register "PcieClkSrcClkReq[3]" = "3"
-	register "PcieClkSrcClkReq[4]" = "4"
-	register "PcieClkSrcClkReq[5]" = "5"
-	register "PcieClkSrcClkReq[6]" = "6"
-	register "PcieClkSrcClkReq[7]" = "7"
-	register "PcieClkSrcClkReq[8]" = "8"
-	register "PcieClkSrcClkReq[9]" = "9"
-	register "PcieClkSrcClkReq[10]" = "10"
-	register "PcieClkSrcClkReq[11]" = "11"
-	register "PcieClkSrcClkReq[12]" = "12"
-	register "PcieClkSrcClkReq[13]" = "13"
-	register "PcieClkSrcClkReq[14]" = "14"
-	register "PcieClkSrcClkReq[15]" = "15"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 11:10
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS3MinAssert" = "3" # 50ms
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 5:4
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS4MinAssert" = "1" # 1s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 19:18
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpSusMinAssert" = "4" # 4s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 17:16
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpAMinAssert" = "4" # 2s
 
 	# Thermal
-	# rdmsr --bitfield 31:24 --decimal 0x1A2
 	register "tcc_offset" = "8"
 
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
-
-# Graphics (soc/intel/cannonlake/graphics.c)
-    register "gfx" = "GMA_STATIC_DISPLAYS(0)"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Enable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
 
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_K"
 	register "gpe0_dw1" = "PMC_GPP_G"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -226,20 +63,43 @@ chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x8520 inherit
 		device pci 00.0 on  end # Host Bridge
-		device pci 01.0 on  end # GPU Port
-		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 01.0 on      # GPU Port
+			# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
+			register "PcieClkSrcUsage[8]" = "0x40"
+			register "PcieClkSrcClkReq[8]" = "8"
+		end
+		device pci 02.0 on      # Integrated Graphics Device
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
+		end
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
+			register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
+			register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)" # USB 2 Left
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
+			register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
+			register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Right
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Shared SRAM
-		#chip drivers/intel/wifi
-		#	register "wake" = "PME_B0_EN_BIT"
-			device pci 14.3 on  end # CNVi wifi
-		#end
+		device pci 14.3 on      # CNVi wifi
+			#chip drivers/intel/wifi
+			#	register "wake" = "PME_B0_EN_BIT"
+			#end
+		end
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on
 			chip drivers/i2c/hid
@@ -260,7 +120,10 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
+			register "SataPortsEnable[4]" = "1" # HDD (SATA4)
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
@@ -269,7 +132,13 @@ chip soc/intel/cannonlake
 		device pci 1b.1 off end # PCI Express Port 18
 		device pci 1b.2 off end # PCI Express Port 19
 		device pci 1b.3 off end # PCI Express Port 20
-		device pci 1b.4 on  end # PCI Express Port 21
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express root port #21 x4, Clock 11 (SSD2)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[11]" = "20"
+			register "PcieClkSrcClkReq[11]" = "11"
+		end
 		device pci 1b.5 off end # PCI Express Port 22
 		device pci 1b.6 off end # PCI Express Port 23
 		device pci 1b.7 off end # PCI Express Port 24
@@ -281,26 +150,52 @@ chip soc/intel/cannonlake
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express root port #9 x4, Clock 10 (SSD)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[10]" = "8"
+			register "PcieClkSrcClkReq[10]" = "10"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
 		device pci 1d.4 off end # PCI Express Port 13
-		device pci 1d.5 on  end # PCI Express Port 14
-		device pci 1d.6 on  end # PCI Express Port 15
+		device pci 1d.5 on      # PCI Express Port 14
+			# PCI Express root port #14 x1, Clock 6 (WLAN)
+			register "PcieRpEnable[13]" = "1"
+			register "PcieRpLtrEnable[13]" = "1"
+			register "PcieClkSrcUsage[6]" = "13"
+			register "PcieClkSrcClkReq[6]" = "6"
+		end
+		device pci 1d.6 on      # PCI Express Port 15
+			# PCI Express root port #15 x1, Clock 5 (LAN)
+			register "PcieRpEnable[14]" = "1"
+			register "PcieRpLtrEnable[14]" = "1"
+			register "PcieClkSrcUsage[5]" = "14"
+			register "PcieClkSrcClkReq[5]" = "5"
+		end
 		device pci 1d.7 off end # PCI Express Port 16
 		device pci 1e.0 off end # UART #0
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
 		device pci 1f.0 on # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+			register "PchHdaAudioLinkDmic0" = "1"
+			register "PchHdaAudioLinkDmic1" = "1"
+		end
 		device pci 1f.4 on  end # SMBus
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE

--- a/src/mainboard/system76/kbl-u/devicetree.cb
+++ b/src/mainboard/system76/kbl-u/devicetree.cb
@@ -71,57 +71,6 @@ chip soc/intel/skylake
 	register "pirqg_routing" = "PCH_IRQ11"
 	register "pirqh_routing" = "PCH_IRQ11"
 
-	# Root port #1 x4 (TBT)
-	register "PcieRpEnable[0]" = "1"
-	register "PcieRpClkReqSupport[0]" = "1"
-	register "PcieRpClkReqNumber[0]" = "4"
-	register "PcieRpClkSrcNumber[0]" = "4"
-	register "PcieRpAdvancedErrorReporting[0]" = "1"
-	register "PcieRpLtrEnable[0]" = "1"
-	register "PcieRpHotPlug[0]" = "1"
-
-	# Root port #5 x1 (LAN)
-	register "PcieRpEnable[4]" = "1"
-	register "PcieRpClkReqSupport[4]" = "1"
-	register "PcieRpClkReqNumber[4]" = "3"
-	register "PcieRpClkSrcNumber[4]" = "3"
-	register "PcieRpAdvancedErrorReporting[4]" = "1"
-	register "PcieRpLtrEnable[4]" = "1"
-
-	# Root port #6 x1 (WLAN)
-	register "PcieRpEnable[5]" = "1"
-	register "PcieRpClkReqSupport[5]" = "1"
-	register "PcieRpClkReqNumber[5]" = "2"
-	register "PcieRpClkSrcNumber[5]" = "2"
-	register "PcieRpAdvancedErrorReporting[5]" = "1"
-	register "PcieRpLtrEnable[5]" = "1"
-
-	# Root port #9 x4 (NVMe)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpClkReqSupport[8]" = "1"
-	register "PcieRpClkReqNumber[8]" = "5"
-	register "PcieRpClkSrcNumber[8]" = "5"
-	register "PcieRpAdvancedErrorReporting[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-
-	# Configure USB2 ports
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"         # Type-A port right
-	register "usb2_ports[1]" = "USB2_PORT_FLEX(OC_SKIP)"        # 3G / LTE
-	register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"      # Type-C port right
-	register "usb2_ports[3]" = "USB2_PORT_FLEX(OC_SKIP)"        # Camera
-	register "usb2_ports[4]" = "USB2_PORT_FLEX(OC_SKIP)"        # Bluetooth
-	register "usb2_ports[5]" = "USB2_PORT_EMPTY"                # NC
-	register "usb2_ports[6]" = "USB2_PORT_FLEX(OC_SKIP)"        # Type-A port left
-	register "usb2_ports[7]" = "USB2_PORT_TYPE_C(OC_SKIP)"      # Type-C port right
-	register "usb2_ports[8]" = "USB2_PORT_EMPTY"                # NC
-	register "usb2_ports[9]" = "USB2_PORT_EMPTY"                # NC
-
-	# Configure USB3 ports
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # Type-A port right
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # 4G
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # Type C port right
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # Type-A port left
-
 	# Power limit
 	register "power_limits_config" = "{
 		.tdp_pl1_override = 20,
@@ -217,7 +166,21 @@ chip soc/intel/skylake
 	device domain 0 on
 		device pci 00.0 on  end # Host Bridge
 		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"         # Type-A port right
+			register "usb2_ports[1]" = "USB2_PORT_FLEX(OC_SKIP)"        # 3G / LTE
+			register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"      # Type-C port right
+			register "usb2_ports[3]" = "USB2_PORT_FLEX(OC_SKIP)"        # Camera
+			register "usb2_ports[4]" = "USB2_PORT_FLEX(OC_SKIP)"        # Bluetooth
+			register "usb2_ports[6]" = "USB2_PORT_FLEX(OC_SKIP)"        # Type-A port left
+			register "usb2_ports[7]" = "USB2_PORT_TYPE_C(OC_SKIP)"      # Type-C port right
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # Type-A port right
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # 4G
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # Type C port right
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)"     # Type-A port left
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Thermal Subsystem
 		device pci 16.0 off end # Management Engine Interface 1
@@ -226,15 +189,48 @@ chip soc/intel/skylake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 17.0 on  end # SATA
-		device pci 1c.0 on  end # PCI Express Port 1
+		device pci 1c.0 on      # PCI Express Port 1
+			# Root port #1 x4 (TBT)
+			register "PcieRpEnable[0]" = "1"
+			register "PcieRpClkReqSupport[0]" = "1"
+			register "PcieRpClkReqNumber[0]" = "4"
+			register "PcieRpClkSrcNumber[0]" = "4"
+			register "PcieRpAdvancedErrorReporting[0]" = "1"
+			register "PcieRpLtrEnable[0]" = "1"
+			register "PcieRpHotPlug[0]" = "1"
+		end
 		device pci 1c.1 off end # PCI Express Port 2
 		device pci 1c.2 off end # PCI Express Port 3
 		device pci 1c.3 off end # PCI Express Port 4
-		device pci 1c.4 on  end # PCI Express Port 5
-		device pci 1c.5 on  end # PCI Express Port 6
+		device pci 1c.4 on      # PCI Express Port 5
+			# Root port #5 x1 (LAN)
+			register "PcieRpEnable[4]" = "1"
+			register "PcieRpClkReqSupport[4]" = "1"
+			register "PcieRpClkReqNumber[4]" = "3"
+			register "PcieRpClkSrcNumber[4]" = "3"
+			register "PcieRpAdvancedErrorReporting[4]" = "1"
+			register "PcieRpLtrEnable[4]" = "1"
+		end
+		device pci 1c.5 on      # PCI Express Port 6
+			# Root port #6 x1 (WLAN)
+			register "PcieRpEnable[5]" = "1"
+			register "PcieRpClkReqSupport[5]" = "1"
+			register "PcieRpClkReqNumber[5]" = "2"
+			register "PcieRpClkSrcNumber[5]" = "2"
+			register "PcieRpAdvancedErrorReporting[5]" = "1"
+			register "PcieRpLtrEnable[5]" = "1"
+		end
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# Root port #9 x4 (NVMe)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpClkReqSupport[8]" = "1"
+			register "PcieRpClkReqNumber[8]" = "5"
+			register "PcieRpClkSrcNumber[8]" = "5"
+			register "PcieRpAdvancedErrorReporting[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12

--- a/src/mainboard/system76/oryp5/devicetree.cb
+++ b/src/mainboard/system76/oryp5/devicetree.cb
@@ -1,5 +1,4 @@
 chip soc/intel/cannonlake
-	# Lock Down
 	register "common_soc_config" = "{
 		.chipset_lockdown = CHIPSET_LOCKDOWN_COREBOOT,
 		// Touchpad I2C bus
@@ -10,22 +9,10 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
-		// /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
 		.tdp_pl1_override = 45,
-		// /sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw
 		.tdp_pl2_override = 78,
 	}"
 
@@ -41,171 +28,29 @@ chip soc/intel/cannonlake
 	register "SerialIoDevMode" = "{
 		[PchSerialIoIndexI2C0] = PchSerialIoPci, // Touchpad I2C bus
 		[PchSerialIoIndexI2C1] = PchSerialIoPci,
-		[PchSerialIoIndexI2C2] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C3] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C4] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C5] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI0] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI1] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI2] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART0] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART1] = PchSerialIoDisabled,
 		[PchSerialIoIndexUART2] = PchSerialIoPci, // Debug console
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "0"
-	register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
-	register "SataPortsEnable[2]" = "0"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "1" # HDD (SATA4)
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
-	register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C/DP
-	register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right
-	register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
-	register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # Per-key RGB
-	register "usb2_ports[5]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # 3G/LTE
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
-	register "usb2_ports[8]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # WLAN/Bluetooth
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C/DP
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Right
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
-	register "usb3_ports[4]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[5]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC_SKIP)" # 3G/LTE
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
-	register "PcieClkSrcUsage[8]" = "0x40"
-
-	# PCI Express root port #9 x4, Clock 12 (SSD)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[12]" = "8"
-
-	# PCI Express root port #14 x1, Clock 13 (WLAN)
-	register "PcieRpEnable[13]" = "1"
-	register "PcieRpLtrEnable[13]" = "1"
-	register "PcieClkSrcUsage[13]" = "13"
-
-	# PCI Express root port #15 x1, Clock 14 (GLAN)
-	register "PcieRpEnable[14]" = "1"
-	register "PcieRpLtrEnable[14]" = "1"
-	register "PcieClkSrcUsage[14]" = "14"
-
-	# PCI Express root port #16 x1, Clock 15 (Card Reader)
-	register "PcieRpEnable[15]" = "1"
-	register "PcieRpLtrEnable[15]" = "1"
-	register "PcieClkSrcUsage[15]" = "15"
-
-	# PCI Express root port #21 x4, Clock 11 (SSD2)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[11]" = "20"
-
-	# Set all clocks sources to the same clock request
-	register "PcieClkSrcClkReq[0]" = "0"
-	register "PcieClkSrcClkReq[1]" = "1"
-	register "PcieClkSrcClkReq[2]" = "2"
-	register "PcieClkSrcClkReq[3]" = "3"
-	register "PcieClkSrcClkReq[4]" = "4"
-	register "PcieClkSrcClkReq[5]" = "5"
-	register "PcieClkSrcClkReq[6]" = "6"
-	register "PcieClkSrcClkReq[7]" = "7"
-	register "PcieClkSrcClkReq[8]" = "8"
-	register "PcieClkSrcClkReq[9]" = "9"
-	register "PcieClkSrcClkReq[10]" = "10"
-	register "PcieClkSrcClkReq[11]" = "11"
-	register "PcieClkSrcClkReq[12]" = "12"
-	register "PcieClkSrcClkReq[13]" = "13"
-	register "PcieClkSrcClkReq[14]" = "14"
-	register "PcieClkSrcClkReq[15]" = "15"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 11:10
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS3MinAssert" = "3" # 50ms
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 5:4
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS4MinAssert" = "1" # 1s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 19:18
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpSusMinAssert" = "4" # 4s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 17:16
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpAMinAssert" = "4" # 2s
 
 	# Thermal
-	# rdmsr --bitfield 31:24 --decimal 0x1A2
 	register "tcc_offset" = "13"
 
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
-
-# Graphics (soc/intel/cannonlake/graphics.c)
-    register "gfx" = "GMA_STATIC_DISPLAYS(0)"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Enable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
 
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_B"
 	register "gpe0_dw1" = "PMC_GPP_G"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -218,20 +63,46 @@ chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x95e6 inherit
 		device pci 00.0 on  end # Host Bridge
-		device pci 01.0 on  end # GPU Port
-		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 01.0 on      # GPU Port
+			# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
+			register "PcieClkSrcUsage[8]" = "0x40"
+			register "PcieClkSrcClkReq[8]" = "8"
+		end
+		device pci 02.0 on      # Integrated Graphics Device
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
+		end
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
+			register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C/DP
+			register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right
+			register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # Per-key RGB
+			register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)" # 3G/LTE
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
+			register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
+			register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # WLAN/Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # Type-C/DP
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Right
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
+			register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC_SKIP)" # 3G/LTE
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Shared SRAM
-		#chip drivers/intel/wifi
-		#	register "wake" = "PME_B0_EN_BIT"
-			device pci 14.3 on  end # CNVi wifi
-		#end
+		device pci 14.3 on      # CNVi wifi
+			#chip drivers/intel/wifi
+			#	register "wake" = "PME_B0_EN_BIT"
+			#end
+		end
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on      # I2C #0
 			# I2C HID not supported on PNP0f13
@@ -245,7 +116,10 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
+			register "SataPortsEnable[4]" = "1" # HDD (SATA4)
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
@@ -254,7 +128,13 @@ chip soc/intel/cannonlake
 		device pci 1b.1 off end # PCI Express Port 18
 		device pci 1b.2 off end # PCI Express Port 19
 		device pci 1b.3 off end # PCI Express Port 20
-		device pci 1b.4 on  end # PCI Express Port 21
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express root port #21 x4, Clock 11 (SSD2)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[11]" = "20"
+			register "PcieClkSrcClkReq[11]" = "11"
+		end
 		device pci 1b.5 off end # PCI Express Port 22
 		device pci 1b.6 off end # PCI Express Port 23
 		device pci 1b.7 off end # PCI Express Port 24
@@ -266,19 +146,47 @@ chip soc/intel/cannonlake
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express root port #9 x4, Clock 12 (SSD)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[12]" = "8"
+			register "PcieClkSrcClkReq[12]" = "12"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
 		device pci 1d.4 off end # PCI Express Port 13
-		device pci 1d.5 off end # PCI Express Port 14
-		device pci 1d.6 on  end # PCI Express Port 15
-		device pci 1d.7 on  end # PCI Express Port 16
+		device pci 1d.5 on      # PCI Express Port 14
+			# PCI Express root port #14 x1, Clock 13 (WLAN)
+			register "PcieRpEnable[13]" = "1"
+			register "PcieRpLtrEnable[13]" = "1"
+			register "PcieClkSrcUsage[13]" = "13"
+			register "PcieClkSrcClkReq[13]" = "13"
+		end
+		device pci 1d.6 on      # PCI Express Port 15
+			# PCI Express root port #15 x1, Clock 14 (GLAN)
+			register "PcieRpEnable[14]" = "1"
+			register "PcieRpLtrEnable[14]" = "1"
+			register "PcieClkSrcUsage[14]" = "14"
+			register "PcieClkSrcClkReq[14]" = "14"
+		end
+		device pci 1d.7 on      # PCI Express Port 16
+			# PCI Express root port #16 x1, Clock 15 (Card Reader)
+			register "PcieRpEnable[15]" = "1"
+			register "PcieRpLtrEnable[15]" = "1"
+			register "PcieClkSrcUsage[15]" = "15"
+			register "PcieClkSrcClkReq[15]" = "15"
+		end
 		device pci 1e.0 off end # UART #0
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
-		device pci 1f.0 on # LPC Interface
+		device pci 1f.0 on      # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end

--- a/src/mainboard/system76/oryp6/devicetree.cb
+++ b/src/mainboard/system76/oryp6/devicetree.cb
@@ -1,5 +1,4 @@
 chip soc/intel/cannonlake
-	# Lock Down
 	register "common_soc_config" = "{
 		.chipset_lockdown = CHIPSET_LOCKDOWN_COREBOOT,
 		// Touchpad I2C bus
@@ -10,22 +9,10 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
-		// /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
 		.tdp_pl1_override = 45,
-		// /sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw
 		.tdp_pl2_override = 90,
 	}"
 
@@ -40,191 +27,29 @@ chip soc/intel/cannonlake
 	# Serial I/O
 	register "SerialIoDevMode" = "{
 		[PchSerialIoIndexI2C0] = PchSerialIoPci, // Touchpad I2C bus
-		[PchSerialIoIndexI2C1] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C2] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C3] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C4] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C5] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI0] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI1] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI2] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART0] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART1] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART2] = PchSerialIoPci, // Debug console
+		[PchSerialIoIndexUART2] = PchSerialIoSkipInit, // Debug console
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "0"
-	register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
-	register "SataPortsEnable[2]" = "0"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "0"
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "0"
-	register "PchHdaAudioLinkDmic1" = "0"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
-	register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
-	register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right 1
-	register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right 2
-	register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # Per-key RGB
-	register "usb2_ports[5]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[6]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
-	register "usb2_ports[8]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[9]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[10]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
-	register "usb3_ports[1]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 right 1
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 right 2
-	register "usb3_ports[4]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[5]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[6]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
-	register "PcieClkSrcUsage[8]" = "0x40"
-
-	# PCI Express root port #9 x4, Clock 12 (SSD1)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[12]" = "8"
-
-	# PCI Express root port #14 x1, Clock 7 (GLAN)
-	register "PcieRpEnable[13]" = "1"
-	register "PcieRpLtrEnable[13]" = "1"
-	register "PcieClkSrcUsage[7]" = "13"
-
-	# PCI Express root port #15 x1, Clock 9 (Card Reader)
-	register "PcieRpEnable[14]" = "1"
-	register "PcieRpLtrEnable[14]" = "1"
-	register "PcieClkSrcUsage[9]" = "14"
-
-	# PCI Express root port #16 x1, Clock 6 (WLAN)
-	register "PcieRpEnable[15]" = "1"
-	register "PcieRpLtrEnable[15]" = "1"
-	register "PcieClkSrcUsage[6]" = "15"
-
-	# PCI Express root port #17 x4, Clock 0 (Thunderbolt)
-	register "PcieRpEnable[16]" = "1"
-	register "PcieRpLtrEnable[16]" = "1"
-	register "PcieRpHotPlug[16]" = "1"
-	register "PcieClkSrcUsage[0]" = "16"
-
-	# PCI Express root port #21 x4, Clock 11 (SSD2)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[11]" = "20"
-
-    # Set all clocks sources to the same clock request
-	register "PcieClkSrcClkReq[0]" = "0"
-	register "PcieClkSrcClkReq[1]" = "1"
-	register "PcieClkSrcClkReq[2]" = "2"
-	register "PcieClkSrcClkReq[3]" = "3"
-	register "PcieClkSrcClkReq[4]" = "4"
-	register "PcieClkSrcClkReq[5]" = "5"
-	register "PcieClkSrcClkReq[6]" = "6"
-	register "PcieClkSrcClkReq[7]" = "7"
-	register "PcieClkSrcClkReq[8]" = "8"
-	register "PcieClkSrcClkReq[9]" = "9"
-	register "PcieClkSrcClkReq[10]" = "10"
-	register "PcieClkSrcClkReq[11]" = "11"
-	register "PcieClkSrcClkReq[12]" = "12"
-	register "PcieClkSrcClkReq[13]" = "13"
-	register "PcieClkSrcClkReq[14]" = "14"
-	register "PcieClkSrcClkReq[15]" = "15"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 11:10
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS3MinAssert" = "3" # 50ms
-	# sudo devmem2 0xfe001020 (pmc_bar + GEN_PMCON_A), bits 5:4
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpS4MinAssert" = "1" # 1s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 19:18
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpSusMinAssert" = "4" # 4s
-	# sudo devmem2 0xfe001818 (pmc_bar + PM_CFG), bits 17:16
-	# WARNING: must then be mapped from FSP value to PCH value
 	register "PchPmSlpAMinAssert" = "4" # 2s
 
 	# Thermal
-	# rdmsr --bitfield 31:24 --decimal 0x1A2
 	register "tcc_offset" = "8"
 
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
-
-# Graphics (soc/intel/cannonlake/graphics.c)
-    register "gfx" = "GMA_STATIC_DISPLAYS(0)"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Enable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
 
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_K"
 	register "gpe0_dw1" = "PMC_GPP_G"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -237,20 +62,43 @@ chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x50d3 inherit
 		device pci 00.0 on  end # Host Bridge
-		device pci 01.0 on  end # GPU Port
-		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 01.0 on      # GPU Port
+			# PCI Express Graphics #0 x16, Clock 8 (NVIDIA GPU)
+			register "PcieClkSrcUsage[8]" = "0x40"
+			register "PcieClkSrcClkReq[8]" = "8"
+		end
+		device pci 02.0 on      # Integrated Graphics Device
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
+		end
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Left
+			register "usb2_ports[1]" = "USB2_PORT_TYPE_C(OC_SKIP)" # Type-C
+			register "usb2_ports[2]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right 1
+			register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)" # USB 3 Right 2
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)" # Per-key RGB
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)" # Camera
+			register "usb2_ports[10]" = "USB2_PORT_MID(OC_SKIP)" # Fingerprint
+			register "usb2_ports[13]" = "USB2_PORT_MID(OC_SKIP)" # Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 Left
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 right 1
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3 right 2
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		device pci 14.2 on  end # Shared SRAM
-		#chip drivers/intel/wifi
-		#	register "wake" = "PME_B0_EN_BIT"
-			device pci 14.3 on  end # CNVi wifi
-		#end
+		device pci 14.3 on      # CNVi wifi
+			#chip drivers/intel/wifi
+			#	register "wake" = "PME_B0_EN_BIT"
+			#end
+		end
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on
 			chip drivers/i2c/hid
@@ -271,16 +119,33 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[1]" = "1" # SSD (SATA1A)
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
 		device pci 1a.0 off end # eMMC
-		device pci 1b.0 on  end # PCI Express Port 17
+		device pci 1b.0 on      # PCI Express Port 17
+			# PCI Express root port #17 x4, Clock 0 (Thunderbolt)
+			register "PcieRpEnable[16]" = "1"
+			register "PcieRpLtrEnable[16]" = "1"
+			register "PcieRpHotPlug[16]" = "1"
+			register "PcieClkSrcUsage[0]" = "16"
+			register "PcieClkSrcClkReq[0]" = "0"
+			register "PcieRpSlotImplemented[16]" = "1"
+		end
 		device pci 1b.1 off end # PCI Express Port 18
 		device pci 1b.2 off end # PCI Express Port 19
 		device pci 1b.3 off end # PCI Express Port 20
-		device pci 1b.4 on  end # PCI Express Port 21
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express root port #21 x4, Clock 11 (SSD2)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[11]" = "20"
+			register "PcieClkSrcClkReq[11]" = "11"
+			register "PcieRpSlotImplemented[20]" = "1"
+		end
 		device pci 1b.5 off end # PCI Express Port 22
 		device pci 1b.6 off end # PCI Express Port 23
 		device pci 1b.7 off end # PCI Express Port 24
@@ -292,32 +157,66 @@ chip soc/intel/cannonlake
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express root port #9 x4, Clock 12 (SSD1)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[12]" = "8"
+			register "PcieClkSrcClkReq[12]" = "12"
+			register "PcieRpSlotImplemented[8]" = "1"
+		end
 		device pci 1d.1 off end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
 		device pci 1d.4 off end # PCI Express Port 13
-		device pci 1d.5 on  end # PCI Express Port 14
-		device pci 1d.6 on  end # PCI Express Port 15
-		device pci 1d.7 on  end # PCI Express Port 16
+		device pci 1d.5 on      # PCI Express Port 14
+			# PCI Express root port #14 x1, Clock 7 (GLAN)
+			register "PcieRpEnable[13]" = "1"
+			register "PcieRpLtrEnable[13]" = "1"
+			register "PcieClkSrcUsage[7]" = "13"
+			register "PcieClkSrcClkReq[7]" = "7"
+			register "PcieRpSlotImplemented[13]" = "1"
+		end
+		device pci 1d.6 on      # PCI Express Port 15
+			# PCI Express root port #15 x1, Clock 9 (Card Reader)
+			register "PcieRpEnable[14]" = "1"
+			register "PcieRpLtrEnable[14]" = "1"
+			register "PcieClkSrcUsage[9]" = "14"
+			register "PcieClkSrcClkReq[9]" = "9"
+			register "PcieRpSlotImplemented[14]" = "1"
+		end
+		device pci 1d.7 on      # PCI Express Port 16
+			# PCI Express root port #16 x1, Clock 6 (WLAN)
+			register "PcieRpEnable[15]" = "1"
+			register "PcieRpLtrEnable[15]" = "1"
+			register "PcieClkSrcUsage[6]" = "15"
+			register "PcieClkSrcClkReq[6]" = "6"
+			register "PcieRpSlotImplemented[15]" = "1"
+		end
 		device pci 1e.0 off end # UART #0
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
-		device pci 1f.0 on # LPC Interface
+		device pci 1f.0 on      # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
-		device pci 1f.4 on
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+		end
+		device pci 1f.4 on      # SMBus
 			chip drivers/i2c/tas5825m
 				register "id" = "0"
 				device i2c 4e on end # (8bit address: 0x9c)
-			end # tas5825m
-		end # SMBus
+			end
+		end
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE
 	end

--- a/src/mainboard/system76/thelio-b1/devicetree.cb
+++ b/src/mainboard/system76/thelio-b1/devicetree.cb
@@ -7,20 +7,12 @@ chip soc/intel/cannonlake
 	# Send an extra VR mailbox command for the PS4 exit issue
 	register "SendVrMbxCmd" = "2"
 
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Enable s0ix
-	register "s0ix_enable" = "0"
-
-	# PM Timer Enabled
-	register "PmTimerDisabled" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
-	#register "tdp_pl1_override" = "15"
-	#register "tdp_pl2_override" = "25"
+	#register "power_limits_config" = "{
+	#	.tdp_pl1_override = 15,
+	#	.tdp_pl2_override = 25,
+	#}"
 
 	# Enable "Intel Speed Shift Technology"
 	register "speed_shift_enable" = "1"
@@ -33,112 +25,14 @@ chip soc/intel/cannonlake
 	#register "enable_c6dram" = "1"
 
 # FSP Silicon (soc/intel/cannonlake/fsp_params.c)
-	# SATA
-	register "SataMode" = "Sata_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "1"
-	register "SataPortsEnable[1]" = "1"
-	register "SataPortsEnable[2]" = "1"
-	register "SataPortsEnable[3]" = "1"
-	register "SataPortsEnable[4]" = "1"
-	register "SataPortsEnable[5]" = "1"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "1"
-	register "PchHdaAudioLinkDmic1" = "1"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB
-	register "SsicPortEnable" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"     # Type-A P1
-	register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)"     # Type-A P2
-	register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"  # Type-C
-	register "usb2_ports[3]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 3.0
-	register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 3.0
-	register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)"     # R USB 3.0
-	register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)"     # R USB 3.0
-	register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 1
-	register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 1
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[13]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P1
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P2
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P3
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P4
-	register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P5
-	register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P6
-	register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P7
-	register "usb3_ports[7]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P8
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"
-
-	# PCI Express Root port #5 x1, Clock 6 (I219-V)
-	register "PcieRpEnable[4]" = "1"
-	register "PcieRpLtrEnable[4]" = "1"
-	register "PcieClkSrcUsage[6]" = "4"
-	register "PcieClkSrcClkReq[6]" = "6"
-
-	# PCI Express Root port #6 x1, Clock 7 (I211-AT)
-	register "PcieRpEnable[5]" = "1"
-	register "PcieRpLtrEnable[5]" = "1"
-	register "PcieClkSrcUsage[7]" = "5"
-	register "PcieClkSrcClkReq[7]" = "7"
-
-	# PCI Express Root port #9 x4, Clock 5 (M.2 P)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[5]" = "8"
-	register "PcieClkSrcClkReq[5]" = "5"
-
-	# PCI Express Root port #21 x4, Clock 3 (M.2 Q)
-	register "PcieRpEnable[20]" = "1"
-	register "PcieRpLtrEnable[20]" = "1"
-	register "PcieClkSrcUsage[3]" = "20"
-	register "PcieClkSrcClkReq[3]" = "3"
-
-	# TODO: Clock 0 is used for PCIE X16
-
 	# Misc
-	register "Device4Enable" = "1"
-	register "HeciEnabled" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	register "PchPmSlpS3MinAssert" = "3"    # 50ms
-	register "PchPmSlpS4MinAssert" = "1"    # 1s
-	register "PchPmSlpSusMinAssert" = "2"   # 500ms
-	register "PchPmSlpAMinAssert" = "4"     # 2s
+	register "PchPmSlpS3MinAssert" = "3"	# 50ms
+	register "PchPmSlpS4MinAssert" = "1"	# 1s
+	register "PchPmSlpSusMinAssert" = "2"	# 500ms
+	register "PchPmSlpAMinAssert" = "4"	# 2s
 
 	# Thermal
 	register "tcc_offset" = "12"
@@ -146,30 +40,11 @@ chip soc/intel/cannonlake
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
 
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -xxx
-	register "gen1_dec" = "0x000c0081"
-	register "gen2_dec" = "0x00040069"
-	register "gen3_dec" = "0x000c3321"
-	register "gen4_dec" = "0x00000000"
-
-	# 8254
-	register "clock_gate_8254" = "0"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Enable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
-
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_C"
 	register "gpe0_dw1" = "PMC_GPP_D"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -183,12 +58,34 @@ chip soc/intel/cannonlake
 		subsystemid 0x1458 0xa0c3 inherit
 		device pci 00.0 on  end # Host Bridge
 		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 off end # SA Thermal device
+		device pci 04.0 off     # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"     # Type-A P1
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)"     # Type-A P2
+			register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"  # Type-C
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 3.0
+			register "usb2_ports[5]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 3.0
+			register "usb2_ports[6]" = "USB2_PORT_MID(OC_SKIP)"     # R USB 3.0
+			register "usb2_ports[7]" = "USB2_PORT_MID(OC_SKIP)"     # R USB 3.0
+			register "usb2_ports[8]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 1
+			register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)"     # F USB 1
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P1
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P2
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P3
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.1 P4
+			register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P5
+			register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P6
+			register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P7
+			register "usb3_ports[7]" = "USB3_PORT_DEFAULT(OC_SKIP)" # USB 3.0 P8
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		#chip drivers/intel/wifi
 		#	register "wake" = "PME_B0_EN_BIT"
@@ -205,20 +102,56 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[0]" = "1"
+			register "SataPortsEnable[1]" = "1"
+			register "SataPortsEnable[2]" = "1"
+			register "SataPortsEnable[3]" = "1"
+			register "SataPortsEnable[4]" = "1"
+			register "SataPortsEnable[5]" = "1"
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 off end # UART #2
 		device pci 1a.0 off end # eMMC
+		device pci 1b.0 off end # PCI Express Port 17
+		device pci 1b.1 off end # PCI Express Port 18
+		device pci 1b.2 off end # PCI Express Port 19
+		device pci 1b.3 off end # PCI Express Port 20
+		device pci 1b.4 on      # PCI Express Port 21
+			# PCI Express Root port #21 x4, Clock 3 (M.2 Q)
+			register "PcieRpEnable[20]" = "1"
+			register "PcieRpLtrEnable[20]" = "1"
+			register "PcieClkSrcUsage[3]" = "20"
+			register "PcieClkSrcClkReq[3]" = "3"
+		end
 		device pci 1c.0 on  end # PCI Express Port 1
 		device pci 1c.1 off end # PCI Express Port 2
 		device pci 1c.2 off end # PCI Express Port 3
 		device pci 1c.3 off end # PCI Express Port 4
-		device pci 1c.4 on  end # PCI Express Port 5
-		device pci 1c.5 off end # PCI Express Port 6
+		device pci 1c.4 on      # PCI Express Port 5
+			# PCI Express Root port #5 x1, Clock 6 (I219-V)
+			register "PcieRpEnable[4]" = "1"
+			register "PcieRpLtrEnable[4]" = "1"
+			register "PcieClkSrcUsage[6]" = "4"
+			register "PcieClkSrcClkReq[6]" = "6"
+		end
+		device pci 1c.5 off     # PCI Express Port 6
+			# PCI Express Root port #6 x1, Clock 7 (I211-AT)
+			register "PcieRpEnable[5]" = "1"
+			register "PcieRpLtrEnable[5]" = "1"
+			register "PcieClkSrcUsage[7]" = "5"
+			register "PcieClkSrcClkReq[7]" = "7"
+		end
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express Root port #9 x4, Clock 5 (M.2 P)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[5]" = "8"
+			register "PcieClkSrcClkReq[5]" = "5"
+		end
 		device pci 1d.1 on  end # PCI Express Port 10
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
@@ -230,10 +163,19 @@ chip soc/intel/cannonlake
 		device pci 1e.1 off end # UART #1
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
-		device pci 1f.0 on  end # LPC Interface
+		device pci 1f.0 on      # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x000c3321"
+			register "gen4_dec" = "0x00000000"
+		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+			register "PchHdaAudioLinkDmic0" = "1"
+			register "PchHdaAudioLinkDmic1" = "1"
+		end
 		device pci 1f.4 on  end # SMBus
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE

--- a/src/mainboard/system76/whl-u/devicetree.cb
+++ b/src/mainboard/system76/whl-u/devicetree.cb
@@ -9,16 +9,6 @@ chip soc/intel/cannonlake
 		},
 	}"
 
-	# Send an extra VR mailbox command for the PS4 exit issue
-	register "SendVrMbxCmd" = "2"
-
-# ACPI (soc/intel/cannonlake/acpi.c)
-	# Disable s0ix
-	register "s0ix_enable" = "0"
-
-	# Disable DPTF
-	register "dptf_enable" = "0"
-
 # CPU (soc/intel/cannonlake/cpu.c)
 	# Power limit
 	register "power_limits_config" = "{
@@ -37,120 +27,17 @@ chip soc/intel/cannonlake
 	# Serial I/O
 	register "SerialIoDevMode" = "{
 		[PchSerialIoIndexI2C0] = PchSerialIoPci,
-		[PchSerialIoIndexI2C1] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C2] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C3] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C4] = PchSerialIoDisabled,
-		[PchSerialIoIndexI2C5] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI0] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI1] = PchSerialIoDisabled,
-		[PchSerialIoIndexSPI2] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART0] = PchSerialIoDisabled,
-		[PchSerialIoIndexUART1] = PchSerialIoDisabled,
 		[PchSerialIoIndexUART2] = PchSerialIoPci,
 	}"
 
-	# SATA
-	register "SataMode" = "SATA_AHCI"
-	register "SataSalpSupport" = "0"
-
-	register "SataPortsEnable[0]" = "1"
-	register "SataPortsEnable[1]" = "0"
-	register "SataPortsEnable[2]" = "1"
-	register "SataPortsEnable[3]" = "0"
-	register "SataPortsEnable[4]" = "0"
-	register "SataPortsEnable[5]" = "0"
-	register "SataPortsEnable[6]" = "0"
-	register "SataPortsEnable[7]" = "0"
-
-	register "SataPortsDevSlp[0]" = "0"
-	register "SataPortsDevSlp[1]" = "0"
-	register "SataPortsDevSlp[2]" = "0"
-	register "SataPortsDevSlp[3]" = "0"
-	register "SataPortsDevSlp[4]" = "0"
-	register "SataPortsDevSlp[5]" = "0"
-	register "SataPortsDevSlp[6]" = "0"
-	register "SataPortsDevSlp[7]" = "0"
-
-	# Audio
-	register "PchHdaDspEnable" = "0"
-	register "PchHdaAudioLinkHda" = "1"
-	register "PchHdaAudioLinkDmic0" = "1"
-	register "PchHdaAudioLinkDmic1" = "1"
-	register "PchHdaAudioLinkSsp0" = "0"
-	register "PchHdaAudioLinkSsp1" = "0"
-	register "PchHdaAudioLinkSsp2" = "0"
-	register "PchHdaAudioLinkSndw1" = "0"
-	register "PchHdaAudioLinkSndw2" = "0"
-	register "PchHdaAudioLinkSndw3" = "0"
-	register "PchHdaAudioLinkSndw4" = "0"
-
-	# USB2
-	register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"		# Type-A port 1
-	register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)"		# 3G / LTE
-	register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"	# Type-C port 3
-	register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)"		# USB Board port 4
-	register "usb2_ports[4]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[5]" = "USB2_PORT_EMPTY"			# Finger print
-	register "usb2_ports[6]" = "USB2_PORT_MAX(OC_SKIP)"     # Camera
-	register "usb2_ports[7]" = "USB2_PORT_EMPTY"			# T17, T18
-	register "usb2_ports[8]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)"		# Bluetooth
-	register "usb2_ports[10]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[11]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[12]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[13]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[14]" = "USB2_PORT_EMPTY"			# NC
-	register "usb2_ports[15]" = "USB2_PORT_EMPTY"			# NC
-
-	# USB3
-	register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)" 	# Type-A port 1
-	register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# 4G
-	register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# Type C port 3
-	register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# USB Board port 4
-	register "usb3_ports[4]" = "USB3_PORT_EMPTY"				# Used by TBT
-	register "usb3_ports[5]" = "USB3_PORT_EMPTY"				# Used by TBT
-	register "usb3_ports[6]" = "USB3_PORT_EMPTY"				# NC
-	register "usb3_ports[7]" = "USB3_PORT_EMPTY"				# NC
-	register "usb3_ports[8]" = "USB3_PORT_EMPTY"				# NC
-	register "usb3_ports[9]" = "USB3_PORT_EMPTY"				# NC
-
-	# PCI Express Root port #5 x4, Clock 4 (TBT)
-	register "PcieRpEnable[4]" = "1"
-	register "PcieRpLtrEnable[4]" = "1"
-	register "PcieRpHotPlug[4]" = "1"
-	register "PcieClkSrcUsage[4]" = "4"
-	register "PcieClkSrcClkReq[4]" = "4"
-
-	# PCI Express Root port #9 x1, Clock 3 (LAN)
-	register "PcieRpEnable[8]" = "1"
-	register "PcieRpLtrEnable[8]" = "1"
-	register "PcieClkSrcUsage[3]" = "8"
-	register "PcieClkSrcClkReq[3]" = "3"
-
-	# PCI Express Root port #10 x1, Clock 2 (WLAN)
-	register "PcieRpEnable[9]" = "1"
-	register "PcieRpLtrEnable[9]" = "0"
-	register "PcieClkSrcUsage[2]" = "9"
-	register "PcieClkSrcClkReq[2]" = "2"
-
-	# PCI Express Root port #13 x4, Clock 5 (NVMe)
-	register "PcieRpEnable[12]" = "1"
-	register "PcieRpLtrEnable[12]" = "1"
-	register "PcieClkSrcUsage[5]" = "12"
-	register "PcieClkSrcClkReq[5]" = "5"
-
 	# Misc
-	register "Device4Enable" = "1"
 	register "AcousticNoiseMitigation" = "1"
-	#register "dmipwroptimize" = "1"
-	#register "satapwroptimize" = "1"
 
 	# Power
-	register "PchPmSlpS3MinAssert" = "3"		# 50ms
-	register "PchPmSlpS4MinAssert" = "1"		# 1s
-	register "PchPmSlpSusMinAssert" = "2"		# 500ms
-	register "PchPmSlpAMinAssert" = "4"		# 2s
+	register "PchPmSlpS3MinAssert" = "3"	# 50ms
+	register "PchPmSlpS4MinAssert" = "1"	# 1s
+	register "PchPmSlpSusMinAssert" = "2"	# 500ms
+	register "PchPmSlpAMinAssert" = "4"	# 2s
 
 	# Thermal
 	register "tcc_offset" = "12"
@@ -158,34 +45,11 @@ chip soc/intel/cannonlake
 	# Serial IRQ Continuous
 	register "serirq_mode" = "SERIRQ_CONTINUOUS"
 
-# Graphics (soc/intel/cannonlake/graphics.c)
-    register "gfx" = "GMA_STATIC_DISPLAYS(0)"
-
-# LPC (soc/intel/cannonlake/lpc.c)
-	# LPC configuration from lspci -s 1f.0 -xxx
-	# Address 0x84: Decode 0x80 - 0x8F (Port 80)
-	register "gen1_dec" = "0x000c0081"
-	# Address 0x88: Decode 0x68 - 0x6F (PMC)
-	register "gen2_dec" = "0x00040069"
-	# Address 0x8C: Decode 0xE00 - 0xEFF (AP/EC command)
-	register "gen3_dec" = "0x00fc0E01"
-	# Address 0x90: Decode 0xF00 - 0xFFF (AP/EC debug)
-	register "gen4_dec" = "0x00fc0F01"
-
-# PMC (soc/intel/cannonlake/pmc.c)
-	# Enable deep Sx states
-	register "deep_s3_enable_ac" = "0"
-	register "deep_s3_enable_dc" = "0"
-	register "deep_s5_enable_ac" = "0"
-	register "deep_s5_enable_dc" = "0"
-	register "deep_sx_config" = "0"
-
 # PM Util (soc/intel/cannonlake/pmutil.c)
 	# GPE configuration
 	# Note that GPE events called out in ASL code rely on this
 	# route. i.e. If this route changes then the affected GPE
 	# offset bits also need to be changed.
-	# sudo devmem2 0xfe001920 (pmc_bar + GPIO_GPE_CFG)
 	register "gpe0_dw0" = "PMC_GPP_C"
 	register "gpe0_dw1" = "PMC_GPP_D"
 	register "gpe0_dw2" = "PMC_GPP_E"
@@ -197,13 +61,34 @@ chip soc/intel/cannonlake
 
 	device domain 0 on
 		device pci 00.0 on  end # Host Bridge
-		device pci 02.0 on  end # Integrated Graphics Device
-		device pci 04.0 on  end # SA Thermal device
+		device pci 02.0 on      # Integrated Graphics Device
+			register "gfx" = "GMA_STATIC_DISPLAYS(0)"
+		end
+		device pci 04.0 on      # SA Thermal device
+			register "Device4Enable" = "1"
+		end
 		device pci 12.0 on  end # Thermal Subsystem
 		device pci 12.5 off end # UFS SCS
 		device pci 12.6 off end # GSPI #2
 		device pci 13.0 off end # Integrated Sensor Hub
-		device pci 14.0 on  end # USB xHCI
+		device pci 14.0 on      # USB xHCI
+			# USB2
+			register "usb2_ports[0]" = "USB2_PORT_MID(OC_SKIP)"		# Type-A port 1
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC_SKIP)"		# 3G / LTE
+			register "usb2_ports[2]" = "USB2_PORT_TYPE_C(OC_SKIP)"		# Type-C port 3
+			register "usb2_ports[3]" = "USB2_PORT_MID(OC_SKIP)"		# USB Board port 4
+			register "usb2_ports[5]" = "USB2_PORT_EMPTY"			# Finger print
+			register "usb2_ports[6]" = "USB2_PORT_MAX(OC_SKIP)"		# Camera
+			register "usb2_ports[7]" = "USB2_PORT_EMPTY"			# T17, T18
+			register "usb2_ports[9]" = "USB2_PORT_MID(OC_SKIP)"		# Bluetooth
+			# USB3
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# Type-A port 1
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# 4G
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# Type C port 3
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC_SKIP)"		# USB Board port 4
+			register "usb3_ports[4]" = "USB3_PORT_EMPTY"			# Used by TBT
+			register "usb3_ports[5]" = "USB3_PORT_EMPTY"			# Used by TBT
+		end
 		device pci 14.1 off end # USB xDCI (OTG)
 		#chip drivers/intel/wifi
 		#	register "wake" = "PME_B0_EN_BIT"
@@ -220,7 +105,10 @@ chip soc/intel/cannonlake
 		device pci 16.3 off end # Management Engine KT Redirection
 		device pci 16.4 off end # Management Engine Interface 3
 		device pci 16.5 off end # Management Engine Interface 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 on      # SATA
+			register "SataPortsEnable[0]" = "1"
+			register "SataPortsEnable[2]" = "1"
+		end
 		device pci 19.0 off end # I2C #4
 		device pci 19.1 off end # I2C #5
 		device pci 19.2 on  end # UART #2
@@ -229,15 +117,40 @@ chip soc/intel/cannonlake
 		device pci 1c.1 off end # PCI Express Port 2
 		device pci 1c.2 off end # PCI Express Port 3
 		device pci 1c.3 off end # PCI Express Port 4
-		device pci 1c.4 on  end # PCI Express Port 5
+		device pci 1c.4 on      # PCI Express Port 5
+			# PCI Express Root port #5 x4, Clock 4 (TBT)
+			register "PcieRpEnable[4]" = "1"
+			register "PcieRpLtrEnable[4]" = "1"
+			register "PcieRpHotPlug[4]" = "1"
+			register "PcieClkSrcUsage[4]" = "4"
+			register "PcieClkSrcClkReq[4]" = "4"
+		end
 		device pci 1c.5 off end # PCI Express Port 6
 		device pci 1c.6 off end # PCI Express Port 7
 		device pci 1c.7 off end # PCI Express Port 8
-		device pci 1d.0 on  end # PCI Express Port 9
-		device pci 1d.1 on  end # PCI Express Port 10
+		device pci 1d.0 on      # PCI Express Port 9
+			# PCI Express Root port #9 x1, Clock 3 (LAN)
+			register "PcieRpEnable[8]" = "1"
+			register "PcieRpLtrEnable[8]" = "1"
+			register "PcieClkSrcUsage[3]" = "8"
+			register "PcieClkSrcClkReq[3]" = "3"
+		end
+		device pci 1d.1 on      # PCI Express Port 10
+			# PCI Express Root port #10 x1, Clock 2 (WLAN)
+			register "PcieRpEnable[9]" = "1"
+			register "PcieRpLtrEnable[9]" = "0"
+			register "PcieClkSrcUsage[2]" = "9"
+			register "PcieClkSrcClkReq[2]" = "2"
+		end
 		device pci 1d.2 off end # PCI Express Port 11
 		device pci 1d.3 off end # PCI Express Port 12
-		device pci 1d.4 on  end # PCI Express Port 13
+		device pci 1d.4 on      # PCI Express Port 13
+			# PCI Express Root port #13 x4, Clock 5 (NVMe)
+			register "PcieRpEnable[12]" = "1"
+			register "PcieRpLtrEnable[12]" = "1"
+			register "PcieClkSrcUsage[5]" = "12"
+			register "PcieClkSrcClkReq[5]" = "5"
+		end
 		device pci 1d.5 off end # PCI Express Port 14
 		device pci 1d.6 off end # PCI Express Port 15
 		device pci 1d.7 off end # PCI Express Port 16
@@ -246,13 +159,21 @@ chip soc/intel/cannonlake
 		device pci 1e.2 off end # GSPI #0
 		device pci 1e.3 off end # GSPI #1
 		device pci 1f.0 on # LPC Interface
+			register "gen1_dec" = "0x000c0081"
+			register "gen2_dec" = "0x00040069"
+			register "gen3_dec" = "0x00fc0e01"
+			register "gen4_dec" = "0x00fc0f01"
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end
 			end
 		end
 		device pci 1f.1 off end # P2SB
 		device pci 1f.2 off end # Power Management Controller
-		device pci 1f.3 on  end # Intel HDA
+		device pci 1f.3 on      # Intel HDA
+			register "PchHdaAudioLinkHda" = "1"
+			register "PchHdaAudioLinkDmic0" = "1"
+			register "PchHdaAudioLinkDmic1" = "1"
+		end
 		device pci 1f.4 on  end # SMBus
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.6 off end # GbE


### PR DESCRIPTION
Upstream is moving towards having registers set within their relevant device. Do this now to reduce the diff for upstreaming and later syncing changes back.

Does not touch the TGL boards or lemp9, which have most of the changes.

- Move registers to devices
- Remove unneeded registers
- Remove extra comments

TODO: Move all of those comments from each board to the docs and/or a script.