### PR TITLE
mb/system76: Remove use of cnl_configure_pads()

### DIFF
--- a/src/mainboard/system76/addw1/ramstage.c
+++ b/src/mainboard/system76/addw1/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSPS_UPD *supd) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/addw2/ramstage.c
+++ b/src/mainboard/system76/addw2/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSPS_UPD *supd) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/bonw14/ramstage.c
+++ b/src/mainboard/system76/bonw14/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSPS_UPD *supd) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/cml-u/ramstage.c
+++ b/src/mainboard/system76/cml-u/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSPS_UPD *supd) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/gaze14/ramstage.c
+++ b/src/mainboard/system76/gaze14/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSP_S_CONFIG *params) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/gaze15/ramstage.c
+++ b/src/mainboard/system76/gaze15/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSPS_UPD *supd) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/oryp5/ramstage.c
+++ b/src/mainboard/system76/oryp5/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSPS_UPD *supd) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/oryp6/ramstage.c
+++ b/src/mainboard/system76/oryp6/ramstage.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSPS_UPD *supd) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/thelio-b1/ramstage.c
+++ b/src/mainboard/system76/thelio-b1/ramstage.c
@@ -1,23 +1,13 @@
-/*
- * This file is part of the coreboot project.
- *
- * Copyright (C) 2019 System76
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 2 of the License.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- */
+/* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/ramstage.h>
+#include <device/device.h>
 #include "gpio.h"
 
-void mainboard_silicon_init_params(FSP_S_CONFIG *params) {
-	/* Configure pads prior to SiliconInit() in case there's any
-	 * dependencies during hardware initialization. */
-	cnl_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
+static void mainboard_init(void *chip_info)
+{
+	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};


### PR DESCRIPTION
Replace FSP hack with mainboard_ops .init() on CFL/CML.