### PR TITLE
galp5: Set DGPU GPIO delays to prevent RTD3 crashes

### DIFF
--- a/src/mainboard/system76/galp5/devicetree.cb
+++ b/src/mainboard/system76/galp5/devicetree.cb
@@ -293,6 +293,10 @@ chip soc/intel/tigerlake
 			chip soc/intel/common/block/pcie/rtd3
 				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_U5)" # DGPU_PWR_EN
 				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_U4)" # DGPU_RST#_PCH
+				register "enable_delay_ms" = "16"
+				register "enable_off_delay_ms" = "4"
+				register "reset_delay_ms" = "10"
+				register "reset_off_delay_ms" = "4"
 				register "srcclk_pin" = "2" # PEG_CLKREQ#
 				device generic 0 on end
 			end


### PR DESCRIPTION
This should fix compute mode on the galp5. Please confirm failure prior to flashing