### PR TITLE
mb/system76: Configure HID IRQs as level triggered

### DIFF
--- a/src/mainboard/system76/addw1/devicetree.cb
+++ b/src/mainboard/system76/addw1/devicetree.cb
@@ -105,7 +105,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_B3_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_B3_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/addw2/devicetree.cb
+++ b/src/mainboard/system76/addw2/devicetree.cb
@@ -104,7 +104,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_A14_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_A14_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/bonw14/devicetree.cb
+++ b/src/mainboard/system76/bonw14/devicetree.cb
@@ -102,7 +102,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_E7_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
+++ b/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
@@ -5,7 +5,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_C23_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/gaze14/devicetree.cb
+++ b/src/mainboard/system76/gaze14/devicetree.cb
@@ -106,7 +106,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_E7_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/gaze15/gpio.h
+++ b/src/mainboard/system76/gaze15/gpio.h
@@ -30,7 +30,7 @@ static const struct pad_config gpio_table[] = {
 	PAD_CFG_NF(GPD3, UP_20K, DEEP, NF1), // PWR_BTN#
 	PAD_CFG_NF(GPD4, NONE, DEEP, NF1), // SUSB#
 	PAD_CFG_NF(GPD5, NONE, DEEP, NF1), // SUSC#
-	PAD_NC(GPD6, NONE, DEEP), // SLP_A# (test point)
+	PAD_NC(GPD6, NONE), // SLP_A# (test point)
 	PAD_CFG_GPI(GPD7, NONE, PWROK), // 100k pull up
 	PAD_CFG_NF(GPD8, NONE, DEEP, NF1), // SUS_CLK_R
 	PAD_NC(GPD9, NONE), // PCH_SLP_WLAN# (test point)
@@ -106,7 +106,7 @@ static const struct pad_config gpio_table[] = {
 	PAD_NC(GPP_C13, NONE),
 	PAD_NC(GPP_C14, NONE),
 	PAD_NC(GPP_C15, NONE),
-	PAD_CFG_NF(GPP_C16, DEEP, NF1), // I2C_SDA_TP
+	PAD_CFG_NF(GPP_C16, NONE, DEEP, NF1), // I2C_SDA_TP
 	PAD_CFG_NF(GPP_C17, NONE, DEEP, NF1), // I2C_SCL_TP
 	PAD_CFG_NF(GPP_C18, NONE, DEEP, NF1), // SMD_7411_I2C
 	PAD_CFG_NF(GPP_C19, NONE, DEEP, NF1), // SMC_7411_I2C
@@ -123,8 +123,8 @@ static const struct pad_config gpio_table[] = {
 	PAD_CFG_GPI(GPP_D4, NONE, DEEP), // I2C2_SDA
 	PAD_CFG_NF(GPP_D5, NONE, DEEP, NF3), // CNVI_RF_RST#
 	PAD_CFG_NF(GPP_D6, NONE, DEEP, NF3), // XTAL_CLKREQ
-	PAD_(GPP_D7, NONE),
-	PAD_(GPP_D8, NONE),
+	PAD_NC(GPP_D7, NONE),
+	PAD_NC(GPP_D8, NONE),
 	PAD_NC(GPP_D9, NONE),
 	PAD_NC(GPP_D10, NONE),
 	PAD_NC(GPP_D11, NONE),

--- a/src/mainboard/system76/lemp9/devicetree.cb
+++ b/src/mainboard/system76/lemp9/devicetree.cb
@@ -100,7 +100,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""ELAN040D""
 				register "generic.desc" = ""ELAN Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_B3_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_B3_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 15 on end

--- a/src/mainboard/system76/oryp6/devicetree.cb
+++ b/src/mainboard/system76/oryp6/devicetree.cb
@@ -103,7 +103,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_E7_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
+++ b/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
@@ -5,7 +5,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_C23_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end


### PR DESCRIPTION
Per upstream [\[1\]], HID over I2C must be level triggered.

[\[1\]]: https://review.coreboot.org/c/coreboot/+/50452
