### PR TITLE
Revert "mb/system76: Configure HID IRQs as level triggered"

### DIFF
--- a/src/mainboard/system76/addw1/devicetree.cb
+++ b/src/mainboard/system76/addw1/devicetree.cb
@@ -105,7 +105,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_B3_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_B3_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/addw2/devicetree.cb
+++ b/src/mainboard/system76/addw2/devicetree.cb
@@ -104,7 +104,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_A14_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_A14_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/bonw14/devicetree.cb
+++ b/src/mainboard/system76/bonw14/devicetree.cb
@@ -102,7 +102,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
+++ b/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
@@ -5,7 +5,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_C23_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/gaze14/devicetree.cb
+++ b/src/mainboard/system76/gaze14/devicetree.cb
@@ -106,7 +106,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/lemp9/devicetree.cb
+++ b/src/mainboard/system76/lemp9/devicetree.cb
@@ -100,7 +100,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""ELAN040D""
 				register "generic.desc" = ""ELAN Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_B3_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_B3_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 15 on end

--- a/src/mainboard/system76/oryp6/devicetree.cb
+++ b/src/mainboard/system76/oryp6/devicetree.cb
@@ -103,7 +103,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end

--- a/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
+++ b/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
@@ -5,7 +5,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
+				register "generic.irq" = "ACPI_IRQ_EDGE_LOW(GPP_C23_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end


### PR DESCRIPTION
This reverts commit c1e02290948e7cf34ed5b9a6d80a167ab0956023.

This change breaks the touchpad on oryp6. We will change these as-needed if it proves to resolve issues, not just because Microsoft says so.