### PR TITLE
gaze15: Add ELAN touchpad settings

### DIFF
--- a/src/mainboard/system76/gaze15/devicetree.cb
+++ b/src/mainboard/system76/gaze15/devicetree.cb
@@ -103,6 +103,14 @@ chip soc/intel/cannonlake
 		device pci 15.0 on
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
+				register "generic.desc" = ""ELAN Touchpad""
+				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
+				register "generic.probed" = "1"
+				register "hid_desc_reg_offset" = "0x01"
+				device i2c 15 on end
+			end
+			chip drivers/i2c/hid
+				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"


### PR DESCRIPTION
This adds the ELAN touchpad settings from the lemp10 in an attempt to support ELAN touchpads on the gaze15.

**Please see https://github.com/system76/firmware-open/pull/181 for testing**