### PR TITLE
mb/system76: acpi: Remove unused define

### DIFF
--- a/src/mainboard/system76/addw1/acpi/mainboard.asl
+++ b/src/mainboard/system76/addw1/acpi/mainboard.asl
@@ -5,7 +5,6 @@
 
 #define EC_GPE_SCI 0x03 /* GPP_K3 */
 #define EC_GPE_SWI 0x06 /* GPP_K6 */
-#define EC_COLOR_KEYBOARD 1
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/addw2/acpi/mainboard.asl
+++ b/src/mainboard/system76/addw2/acpi/mainboard.asl
@@ -5,7 +5,6 @@
 
 #define EC_GPE_SCI 0x03 /* GPP_K3 */
 #define EC_GPE_SWI 0x06 /* GPP_K6 */
-#define EC_COLOR_KEYBOARD 1
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/cml-u/acpi/mainboard.asl
+++ b/src/mainboard/system76/cml-u/acpi/mainboard.asl
@@ -3,13 +3,6 @@
 #define EC_GPE_SCI 0x50 /* GPP_E16 */
 #define EC_GPE_SWI 0x29 /* GPP_D9 */
 
-#if defined(CONFIG_BOARD_SYSTEM76_DARP6)
-	#define EC_COLOR_KEYBOARD 1
-#elif defined(CONFIG_BOARD_SYSTEM76_GALP4)
-	#define EC_COLOR_KEYBOARD 0
-#else
-	#error Unknown Mainboard
-#endif
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/gaze14/acpi/mainboard.asl
+++ b/src/mainboard/system76/gaze14/acpi/mainboard.asl
@@ -5,7 +5,6 @@
 
 #define EC_GPE_SCI 0x03 /* GPP_K3 */
 #define EC_GPE_SWI 0x06 /* GPP_K6 */
-#define EC_COLOR_KEYBOARD 1
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/gaze15/acpi/mainboard.asl
+++ b/src/mainboard/system76/gaze15/acpi/mainboard.asl
@@ -5,7 +5,6 @@
 
 #define EC_GPE_SCI 0x03 /* GPP_K3 */
 #define EC_GPE_SWI 0x06 /* GPP_K6 */
-#define EC_COLOR_KEYBOARD 1
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/lemp9/acpi/mainboard.asl
+++ b/src/mainboard/system76/lemp9/acpi/mainboard.asl
@@ -2,7 +2,6 @@
 
 #define EC_GPE_SCI 0x50 /* GPP_E16 */
 #define EC_GPE_SWI 0x29 /* GPP_D9 */
-#define EC_COLOR_KEYBOARD 0
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/oryp5/acpi/mainboard.asl
+++ b/src/mainboard/system76/oryp5/acpi/mainboard.asl
@@ -5,7 +5,6 @@
 
 #define EC_GPE_SCI 0x17 /* GPP_B23 */
 #define EC_GPE_SWI 0x26 /* GPP_G6 */
-#define EC_COLOR_KEYBOARD 1
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB)

--- a/src/mainboard/system76/oryp6/acpi/mainboard.asl
+++ b/src/mainboard/system76/oryp6/acpi/mainboard.asl
@@ -5,7 +5,6 @@
 
 #define EC_GPE_SCI 0x03 /* GPP_K3 */
 #define EC_GPE_SWI 0x06 /* GPP_K6 */
-#define EC_COLOR_KEYBOARD 1
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/oryp7/acpi/mainboard.asl
+++ b/src/mainboard/system76/oryp7/acpi/mainboard.asl
@@ -5,7 +5,6 @@
 
 #define EC_GPE_SCI 0x03 /* GPP_K3 */
 #define EC_GPE_SWI 0x06 /* GPP_K6 */
-#define EC_COLOR_KEYBOARD 1
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {

--- a/src/mainboard/system76/whl-u/acpi/mainboard.asl
+++ b/src/mainboard/system76/whl-u/acpi/mainboard.asl
@@ -2,14 +2,6 @@
 
 #define EC_GPE_SCI 0x50 /* GPP_E16 */
 #define EC_GPE_SWI 0x29 /* GPP_D9 */
-
-#if defined(CONFIG_BOARD_SYSTEM76_DARP5)
-	#define EC_COLOR_KEYBOARD 1
-#elif defined(CONFIG_BOARD_SYSTEM76_GALP3_C)
-	#define EC_COLOR_KEYBOARD 0
-#else
-	#error Unknown Mainboard
-#endif
 #include <ec/system76/ec/acpi/ec.asl>
 
 Scope (\_SB) {


### PR DESCRIPTION
The `EC_COLOR_KEYBOARD` define is not used by the EC ASL. A Kconfig selection is used instead.
