### PR TITLE
Add Kconfig for disabling IME

### DIFF
--- a/src/soc/intel/cannonlake/Kconfig
+++ b/src/soc/intel/cannonlake/Kconfig
@@ -358,4 +358,8 @@ config INTEL_GMA_BCLM_OFFSET
 config INTEL_GMA_BCLM_WIDTH
 	default 32
 
+config DISABLE_ME
+	bool "Disable the IME by setting the HAP bit at run-time"
+	default y
+
 endif

--- a/src/soc/intel/cannonlake/me.c
+++ b/src/soc/intel/cannonlake/me.c
@@ -154,8 +154,7 @@ void dump_me_status(void *unused)
 		hfsts6.fields.txt_support ? "YES" : "NO");
 }
 
-#define DISABLE_ME 1
-#if DISABLE_ME
+#if CONFIG(DISABLE_ME)
 
 static void disable_me(void* unused)
 {

--- a/src/soc/intel/tigerlake/Kconfig
+++ b/src/soc/intel/tigerlake/Kconfig
@@ -250,4 +250,9 @@ config EARLY_TCSS_DISPLAY
 	help
 	  Enable displays to be detected over Type-C ports during boot.
 
+config DISABLE_ME
+	bool "Disable the IME by setting the HAP bit at run-time"
+	# XXX: Prevents CPU from reaching C10
+	default n
+
 endif

--- a/src/soc/intel/tigerlake/me.c
+++ b/src/soc/intel/tigerlake/me.c
@@ -163,5 +163,33 @@ static void dump_me_status(void *unused)
 		hfsts6.fields.txt_support ? "YES" : "NO");
 }
 
+#if CONFIG(DISABLE_ME)
+
+static void disable_me(void* unused)
+{
+	printk(BIOS_DEBUG, "ME: send disable message\n");
+
+	struct disable_command {
+		uint32_t hdr;
+		uint32_t rule_id;
+		uint8_t rule_len;
+		uint32_t rule_data;
+	} __packed msg;
+	msg.hdr = 0x303;
+	msg.rule_id = 6;
+	msg.rule_len = 4;
+	msg.rule_data = 0;
+
+	if (!heci_send(&msg, sizeof(msg), BIOS_HOST_ADDR, HECI_MKHI_ADDR))
+		printk(BIOS_ERR, "ME: Error sending DISABLE msg\n");
+	dump_me_status(unused);
+}
+
+BOOT_STATE_INIT_ENTRY(BS_OS_RESUME_CHECK, BS_ON_EXIT, disable_me, NULL);
+
+#else // DISABLE_ME
+
 BOOT_STATE_INIT_ENTRY(BS_DEV_ENABLE, BS_ON_EXIT, print_me_fw_version, NULL);
 BOOT_STATE_INIT_ENTRY(BS_OS_RESUME_CHECK, BS_ON_EXIT, dump_me_status, NULL);
+
+#endif // DISABLE_ME


### PR DESCRIPTION
Replace hard-coded value with a Kconfig option, enabled on CNL to preserve behavior.

Add it to TGL as well, defaulting to disabled to avoid the S0ix issue.