### PR TITLE
mb/system76: Fix CMOS layouts

### DIFF
--- a/src/mainboard/system76/addw1/cmos.layout
+++ b/src/mainboard/system76/addw1/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/addw2/cmos.layout
+++ b/src/mainboard/system76/addw2/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/bonw14/cmos.layout
+++ b/src/mainboard/system76/bonw14/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/cml-u/cmos.layout
+++ b/src/mainboard/system76/cml-u/cmos.layout
@@ -2,19 +2,27 @@
 
 entries
 
-#start  length  type    id      name
-0       384     r       0       reserved_memory
-384     1       e       1       DisplayPort_Output
-408     1       h       1       preserve_smmstore
-984     16      h       0       check_sum
+0	384	r	0	reserved_memory
+
+# RTC_BOOT_BYTE (coreboot hardcoded)
+384	1	e	4	boot_option
+388	4	h	0	reboot_counter
+
+392	1	e	8	DisplayPort_Output
+408	1	h	1	preserve_smmstore
+984	16	h	0	check_sum
 
 enumerations
 
-#ID     value   text
-1       0       Mini_DisplayPort
-1       1       USB-C
+1	0	Disable
+1	1	Enable
+
+4	0	Fallback
+4	1	Normal
+
+8	0	Mini_DisplayPort
+8	1	USB-C
 
 checksums
 
-#checksum   start   end     location
-checksum    384     983     984
+checksum 392 983 984

--- a/src/mainboard/system76/darp7/cmos.layout
+++ b/src/mainboard/system76/darp7/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/galp5/cmos.layout
+++ b/src/mainboard/system76/galp5/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/gaze14/cmos.layout
+++ b/src/mainboard/system76/gaze14/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/gaze15/cmos.layout
+++ b/src/mainboard/system76/gaze15/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/kbl-u/cmos.layout
+++ b/src/mainboard/system76/kbl-u/cmos.layout
@@ -2,19 +2,27 @@
 
 entries
 
-#start  length  type    id      name
-0       384     r       0       reserved_memory
-384     1       e       1       DisplayPort_Output
-408     1       h       1       preserve_smmstore
-984     16      h       0       check_sum
+0	384	r	0	reserved_memory
+
+# RTC_BOOT_BYTE (coreboot hardcoded)
+384	1	e	4	boot_option
+388	4	h	0	reboot_counter
+
+392	1	e	8	DisplayPort_Output
+408	1	h	1	preserve_smmstore
+984	16	h	0	check_sum
 
 enumerations
 
-#ID     value   text
-1       0       Mini_DisplayPort
-1       1       USB-C
+1	0	Disable
+1	1	Enable
+
+4	0	Fallback
+4	1	Normal
+
+8	0	Mini_DisplayPort
+8	1	USB-C
 
 checksums
 
-#checksum   start   end     location
-checksum    384     983     984
+checksum 392 983 984

--- a/src/mainboard/system76/lemp10/cmos.layout
+++ b/src/mainboard/system76/lemp10/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/lemp9/cmos.layout
+++ b/src/mainboard/system76/lemp9/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/oryp5/cmos.layout
+++ b/src/mainboard/system76/oryp5/cmos.layout
@@ -5,7 +5,7 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
 #395	4	e	3	debug_level
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/oryp6/cmos.layout
+++ b/src/mainboard/system76/oryp6/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/oryp7/cmos.layout
+++ b/src/mainboard/system76/oryp7/cmos.layout
@@ -5,10 +5,10 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+#395	4	e	6	debug_level
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
@@ -17,18 +17,18 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
 
 checksums
 

--- a/src/mainboard/system76/whl-u/cmos.layout
+++ b/src/mainboard/system76/whl-u/cmos.layout
@@ -2,19 +2,27 @@
 
 entries
 
-#start  length  type    id      name
-0       384     r       0       reserved_memory
-384     1       e       1       DisplayPort_Output
-408     1       h       1       preserve_smmstore
-984     16      h       0       check_sum
+0	384	r	0	reserved_memory
+
+# RTC_BOOT_BYTE (coreboot hardcoded)
+384	1	e	4	boot_option
+388	4	h	0	reboot_counter
+
+392	1	e	8	DisplayPort_Output
+408	1	h	1	preserve_smmstore
+984	16	h	0	check_sum
 
 enumerations
 
-#ID     value   text
-1       0       Mini_DisplayPort
-1       1       USB-C
+1	0	Disable
+1	1	Enable
+
+4	0	Fallback
+4	1	Normal
+
+8	0	Mini_DisplayPort
+8	1	USB-C
 
 checksums
 
-#checksum   start   end     location
-checksum    384     983     984
+checksum 392 983 984


### PR DESCRIPTION
`DisplayPort_Output` conflicts with `RTC_BOOT_BYTE`. Move it to 392 and adjust the checksum to start there as well.

Modify enum index for `debug_level` and `boot_option` to match other boards across coreboot.
