### PR TITLE
mb/system76/*: Add subsystemid to TGL models

### DIFF
--- a/src/mainboard/system76/darp7/devicetree.cb
+++ b/src/mainboard/system76/darp7/devicetree.cb
@@ -108,6 +108,8 @@ chip soc/intel/tigerlake
 	end
 
 	device domain 0 on
+		subsystemid 0x1558 0x51a1 inherit
+
 		#From CPU EDS(575683)
 		device ref system_agent on end
 		device ref igpu on

--- a/src/mainboard/system76/galp5/devicetree.cb
+++ b/src/mainboard/system76/galp5/devicetree.cb
@@ -108,6 +108,8 @@ chip soc/intel/tigerlake
 	end
 
 	device domain 0 on
+		subsystemid 0x1558 0x4018 inherit
+
 		#From CPU EDS(575683)
 		device ref system_agent on end
 		device ref igpu on

--- a/src/mainboard/system76/gaze16/variants/3050/overridetree.cb
+++ b/src/mainboard/system76/gaze16/variants/3050/overridetree.cb
@@ -1,5 +1,7 @@
 chip soc/intel/tigerlake
 	device domain 0 on
+		subsystemid 0x1558 0x5015 inherit
+
 		device ref peg1 on
 			# PCIe PEG2 (remapped to PEG1 by FSP) x8, Clock 0 (DGPU)
 			register "PcieClkSrcUsage[0]" = "0x42"

--- a/src/mainboard/system76/gaze16/variants/3060/overridetree.cb
+++ b/src/mainboard/system76/gaze16/variants/3060/overridetree.cb
@@ -1,5 +1,7 @@
 chip soc/intel/tigerlake
 	device domain 0 on
+		subsystemid 0x1558 0x50e1 inherit
+
 		device ref peg1 on
 			# PCIe PEG1 x16, Clock 9 (DGPU)
 			register "PcieClkSrcUsage[9]" = "0x41"

--- a/src/mainboard/system76/lemp10/devicetree.cb
+++ b/src/mainboard/system76/lemp10/devicetree.cb
@@ -108,6 +108,8 @@ chip soc/intel/tigerlake
 	end
 
 	device domain 0 on
+		subsystemid 0x1558 0x14a1 inherit
+
 		#From CPU EDS(575683)
 		device ref system_agent on end
 		device ref igpu on

--- a/src/soc/intel/tigerlake/fsp_params.c
+++ b/src/soc/intel/tigerlake/fsp_params.c
@@ -378,6 +378,64 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 	/* Disable C1 C-state Demotion */
 	params->C1StateAutoDemotion = 0;
 
+	/*
+	 * Prevent FSP from programming write-once subsystem IDs by providing
+	 * a custom SSID table. Must have at least one entry for the FSP to
+	 * use the table.
+	 */
+	struct svid_ssid_init_entry {
+		union {
+			struct {
+				uint64_t reg:12;	/* Register offset */
+				uint64_t function:3;
+				uint64_t device:5;
+				uint64_t bus:8;
+				uint64_t :4;
+				uint64_t segment:16;
+				uint64_t :16;
+			};
+			uint64_t segbusdevfuncregister;
+		};
+		struct {
+			uint16_t svid;
+			uint16_t ssid;
+		};
+		uint32_t reserved;
+	};
+
+	/*
+	 * The xHCI and HDA devices have RW/L rather than RW/O registers for
+	 * subsystem IDs and so must be written before FspSiliconInit locks
+	 * them with their default values.
+	 */
+	const pci_devfn_t devfn_table[] = { PCH_DEVFN_XHCI, PCH_DEVFN_HDA };
+	static struct svid_ssid_init_entry ssid_table[ARRAY_SIZE(devfn_table)];
+
+	for (i = 0; i < ARRAY_SIZE(devfn_table); i++) {
+		ssid_table[i].reg	= PCI_SUBSYSTEM_VENDOR_ID;
+		ssid_table[i].device	= PCI_SLOT(devfn_table[i]);
+		ssid_table[i].function	= PCI_FUNC(devfn_table[i]);
+		dev = pcidev_path_on_root(devfn_table[i]);
+		if (dev) {
+			ssid_table[i].svid = dev->subsystem_vendor;
+			ssid_table[i].ssid = dev->subsystem_device;
+		}
+	}
+
+	params->SiSsidTablePtr = (uintptr_t)ssid_table;
+	params->SiNumberOfSsidTableEntry = ARRAY_SIZE(ssid_table);
+
+	/*
+	 * Replace the default SVID:SSID value with the values specified in
+	 * the devicetree for the root device.
+	 */
+	dev = pcidev_path_on_root(SA_DEVFN_ROOT);
+	params->SiCustomizedSvid = dev->subsystem_vendor;
+	params->SiCustomizedSsid = dev->subsystem_device;
+
+	/* Ensure FSP will program the registers */
+	params->SiSkipSsidProgramming = 0;
+
 	mainboard_silicon_init_params(params);
 }
 


### PR DESCRIPTION
Cherry-pick f3c4f29ddda to fix subsystem IDs on TGL. Add subsystem IDs to TGL boards.

Check subsystem IDs with `lspci -vnn`.