### PR TITLE
mb/system76/*: Update CMOS layouts and defaults

### DIFF
--- a/src/mainboard/system76/addw1/cmos.default
+++ b/src/mainboard/system76/addw1/cmos.default
@@ -1,2 +1,4 @@
 boot_option=Fallback
+debug_level=Debug
+power_on_after_fail=Enable
 preserve_smmstore=0

--- a/src/mainboard/system76/addw1/cmos.layout
+++ b/src/mainboard/system76/addw1/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/addw2/cmos.default
+++ b/src/mainboard/system76/addw2/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/addw2/cmos.layout
+++ b/src/mainboard/system76/addw2/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/bonw14/cmos.default
+++ b/src/mainboard/system76/bonw14/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/bonw14/cmos.layout
+++ b/src/mainboard/system76/bonw14/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/cml-u/cmos.default
+++ b/src/mainboard/system76/cml-u/cmos.default
@@ -1,2 +1,4 @@
+boot_option=Fallback
+debug_level=Debug
 DisplayPort_Output=Mini_DisplayPort
 preserve_smmstore=0

--- a/src/mainboard/system76/cml-u/cmos.layout
+++ b/src/mainboard/system76/cml-u/cmos.layout
@@ -8,8 +8,13 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-392	1	e	8	DisplayPort_Output
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+411	1	e	8	DisplayPort_Output
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -20,9 +25,23 @@ enumerations
 4	0	Fallback
 4	1	Normal
 
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
+
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 8	0	Mini_DisplayPort
 8	1	USB-C
 
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/darp7/cmos.default
+++ b/src/mainboard/system76/darp7/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/darp7/cmos.layout
+++ b/src/mainboard/system76/darp7/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/galp5/cmos.default
+++ b/src/mainboard/system76/galp5/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/galp5/cmos.layout
+++ b/src/mainboard/system76/galp5/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/gaze14/cmos.default
+++ b/src/mainboard/system76/gaze14/cmos.default
@@ -1,2 +1,4 @@
 boot_option=Fallback
+debug_level=Debug
+power_on_after_fail=Enable
 preserve_smmstore=0

--- a/src/mainboard/system76/gaze14/cmos.layout
+++ b/src/mainboard/system76/gaze14/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/gaze15/cmos.default
+++ b/src/mainboard/system76/gaze15/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/gaze15/cmos.layout
+++ b/src/mainboard/system76/gaze15/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/gaze16/cmos.default
+++ b/src/mainboard/system76/gaze16/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/gaze16/cmos.layout
+++ b/src/mainboard/system76/gaze16/cmos.layout
@@ -5,11 +5,15 @@ entries
 0	384	r	0	reserved_memory
 
 # RTC_BOOT_BYTE (coreboot hardcoded)
-384	1	e	2	boot_option
+384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -17,19 +21,23 @@ enumerations
 1	0	Disable
 1	1	Enable
 
-2	0	Fallback
-2	1	Normal
+4	0	Fallback
+4	1	Normal
 
-3	0	Emergency
-3	1	Alert
-3	2	Critical
-3	3	Error
-3	4	Warning
-3	5	Notice
-3	6	Info
-3	7	Debug
-3	8	Spew
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
+
+7	0	Disable
+7	1	Enable
+7	2	Keep
 
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/kbl-u/cmos.default
+++ b/src/mainboard/system76/kbl-u/cmos.default
@@ -1,2 +1,4 @@
+boot_option=Fallback
+debug_level=Debug
 DisplayPort_Output=Mini_DisplayPort
 preserve_smmstore=0

--- a/src/mainboard/system76/kbl-u/cmos.layout
+++ b/src/mainboard/system76/kbl-u/cmos.layout
@@ -8,8 +8,13 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-392	1	e	8	DisplayPort_Output
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+411	1	e	8	DisplayPort_Output
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -20,9 +25,23 @@ enumerations
 4	0	Fallback
 4	1	Normal
 
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
+
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 8	0	Mini_DisplayPort
 8	1	USB-C
 
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/lemp10/cmos.default
+++ b/src/mainboard/system76/lemp10/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/lemp10/cmos.layout
+++ b/src/mainboard/system76/lemp10/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/lemp9/cmos.default
+++ b/src/mainboard/system76/lemp9/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/lemp9/cmos.layout
+++ b/src/mainboard/system76/lemp9/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/oryp5/cmos.default
+++ b/src/mainboard/system76/oryp5/cmos.default
@@ -1,2 +1,4 @@
 boot_option=Fallback
+debug_level=Debug
+power_on_after_fail=Enable
 preserve_smmstore=0

--- a/src/mainboard/system76/oryp5/cmos.layout
+++ b/src/mainboard/system76/oryp5/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	3	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/oryp6/cmos.default
+++ b/src/mainboard/system76/oryp6/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/oryp6/cmos.layout
+++ b/src/mainboard/system76/oryp6/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/oryp7/cmos.default
+++ b/src/mainboard/system76/oryp7/cmos.default
@@ -1,2 +1,3 @@
 boot_option=Fallback
+debug_level=Debug
 preserve_smmstore=0

--- a/src/mainboard/system76/oryp7/cmos.layout
+++ b/src/mainboard/system76/oryp7/cmos.layout
@@ -8,8 +8,12 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-#395	4	e	6	debug_level
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -30,6 +34,10 @@ enumerations
 6	7	Debug
 6	8	Spew
 
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 checksums
 
-checksum 392 983 984
+checksum 408 983 984

--- a/src/mainboard/system76/whl-u/cmos.default
+++ b/src/mainboard/system76/whl-u/cmos.default
@@ -1,2 +1,4 @@
+boot_option=Fallback
+debug_level=Debug
 DisplayPort_Output=Mini_DisplayPort
 preserve_smmstore=0

--- a/src/mainboard/system76/whl-u/cmos.layout
+++ b/src/mainboard/system76/whl-u/cmos.layout
@@ -8,8 +8,13 @@ entries
 384	1	e	4	boot_option
 388	4	h	0	reboot_counter
 
-392	1	e	8	DisplayPort_Output
+# RTC_CLK_ALTCENTURY
+400	8	r	0	century
+
 408	1	h	1	preserve_smmstore
+#409	2	e	7	power_on_after_fail
+411	1	e	8	DisplayPort_Output
+412	4	e	6	debug_level
 984	16	h	0	check_sum
 
 enumerations
@@ -20,9 +25,23 @@ enumerations
 4	0	Fallback
 4	1	Normal
 
+6	0	Emergency
+6	1	Alert
+6	2	Critical
+6	3	Error
+6	4	Warning
+6	5	Notice
+6	6	Info
+6	7	Debug
+6	8	Spew
+
+7	0	Disable
+7	1	Enable
+7	2	Keep
+
 8	0	Mini_DisplayPort
 8	1	USB-C
 
 checksums
 
-checksum 392 983 984
+checksum 408 983 984


### PR DESCRIPTION
Windows will write to the century byte (0x32), causing the option table checksum to be invalid and reset all options to their default values. Move options and checksum to start after the century byte.

Add missing default for `boot_option`.
Add `debug_level`.

Reserve space for `power_on_after_fail`. It cannot be safely added to existing boards because they do not boot with it set to `Disable`, which is what coreboot will read with the new entry. A CMOS reset would be required for coreboot to write `Enable` to the bits.

Resolves: system76/firmware-open#218
Upstream: [CB:57055](https://review.coreboot.org/c/coreboot/+/57055)