### PR TITLE
mb/system76/{galp5,gaze16}: acpi: Save/Restore NVIDIA SSID

### DIFF
--- a/src/mainboard/system76/galp5/acpi/dgpu.asl
+++ b/src/mainboard/system76/galp5/acpi/dgpu.asl
@@ -1,30 +1,32 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-Scope (\_SB.PCI0.RP01) {
-    Device (DEV0) {
-        Name(_ADR, 0x00000000)
+Scope (\_SB.PCI0.RP05) {
+	Device (DEV0) {
+		Name(_ADR, 0x00000000)
+		Name(SSID, 0x00000000)
 
-        OperationRegion (PCIC, PCI_Config, 0x00, 0x50)
-        Field (PCIC, DwordAcc, NoLock, Preserve) {
-            Offset (0x40),
-            SSID, 32
-        }
+		OperationRegion (PCIC, PCI_Config, 0x00, 0x50)
+		Field (PCIC, DwordAcc, NoLock, Preserve) {
+			Offset (0x40),
+			NVID, 32
+		}
 
-        Name (_PR0, Package () { PWRR })
-        Name (_PR3, Package () { PWRR })
-        PowerResource (PWRR, 0, 0) {
-            Name (_STA, 1)
+		Name (_PR0, Package () { PWRR })
+		Name (_PR3, Package () { PWRR })
+		PowerResource (PWRR, 0, 0) {
+			Name (_STA, 1)
 
-            Method (_ON) {
-                ^^SSID = 0x40181558
-                Printf("GPU _ON %o", ToHexString(^^SSID))
-                _STA = 1
-            }
+			Method (_ON) {
+				^^NVID = ^^SSID
+				Printf("GPU _ON %o", ToHexString(^^SSID))
+				_STA = 1
+			}
 
-            Method (_OFF) {
-                Printf("GPU _OFF %o", ToHexString(^^SSID))
-                _STA = 0
-            }
-        }
-    }
+			Method (_OFF) {
+				^^SSID = ^^NVID
+				Printf("GPU _OFF %o", ToHexString(^^SSID))
+				_STA = 0
+			}
+		}
+	}
 }

--- a/src/mainboard/system76/gaze16/acpi/dgpu.asl
+++ b/src/mainboard/system76/gaze16/acpi/dgpu.asl
@@ -1,30 +1,32 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-Scope (\_SB.PCI0.RP01) {
-    Device (DEV0) {
-        Name(_ADR, 0x00000000)
+Scope (\_SB.PCI0.PEG1) {
+	Device (DEV0) {
+		Name(_ADR, 0x00000000)
+		Name(SSID, 0x00000000)
 
-        OperationRegion (PCIC, PCI_Config, 0x00, 0x50)
-        Field (PCIC, DwordAcc, NoLock, Preserve) {
-            Offset (0x40),
-            SSID, 32
-        }
+		OperationRegion (PCIC, PCI_Config, 0x00, 0x50)
+		Field (PCIC, DwordAcc, NoLock, Preserve) {
+			Offset (0x40),
+			NVID, 32
+		}
 
-        Name (_PR0, Package () { PWRR })
-        Name (_PR3, Package () { PWRR })
-        PowerResource (PWRR, 0, 0) {
-            Name (_STA, 1)
+		Name (_PR0, Package () { PWRR })
+		Name (_PR3, Package () { PWRR })
+		PowerResource (PWRR, 0, 0) {
+			Name (_STA, 1)
 
-            Method (_ON) {
-                ^^SSID = 0x50171558
-                Printf("GPU _ON %o", ToHexString(^^SSID))
-                _STA = 1
-            }
+			Method (_ON) {
+				^^NVID = ^^SSID
+				Printf("GPU _ON %o", ToHexString(^^SSID))
+				_STA = 1
+			}
 
-            Method (_OFF) {
-                Printf("GPU _OFF %o", ToHexString(^^SSID))
-                _STA = 0
-            }
-        }
-    }
+			Method (_OFF) {
+				^^SSID = ^^NVID
+				Printf("GPU _OFF %o", ToHexString(^^SSID))
+				_STA = 0
+			}
+		}
+	}
 }


### PR DESCRIPTION
Save NVIDIA device subsystem ID before turning off the GPU, and restore
it after turning on the GPU. This prevents to GPU from having the
default 10de:0000 SSID on RTD3 _ON.

Fixes formatting and device scope.

Tested on gaze16-3050 by checking lspci after RTD3 _OFF.

    $ cat /sys/bus/pci/devices/0000\:01\:00.0/power/runtime_status
    suspended

    $ lspci -s 01:00.0 -vnn | grep Subsystem
    Subsystem: CLEVO/KAPOK Computer GA107M [GeForce RTX 3050 Mobile] [1558:5015]

Ref: system76/firmware-open#231