### PR TITLE
ec/system76/ec: Implement `_BIX` acpi method, exposing cycle count

### DIFF
--- a/src/ec/system76/ec/acpi/battery.asl
+++ b/src/ec/system76/ec/acpi/battery.asl
@@ -96,6 +96,83 @@ Device (BAT0)
 		Return (PBIF) /* \_SB_.BAT0.PBIF */
 	}
 
+	Name (PBIX, Package (0x14)
+	{
+		Zero, // 0 - Revision
+		One, // 1 - Power Unit
+		0xFFFFFFFF, // 2 - Design Capacity
+		0xFFFFFFFF, // 3 - Last Full Charge Capacity
+		One, // 4 - Battery Technology
+		0xFFFFFFFF, // 5 - Design Voltage
+		Zero, // 6 - Design Capacity of Warning
+		Zero, // 7 - Design Capacity of Low
+		Zero, // 8 - Cycle Count
+		98000, // 9 - Measurement Accuracy
+		0xFFFFFFFF, // 10 - Max Sampling Time
+		0xFFFFFFFF, // 11 - Min Sampling Time
+		0xFFFFFFFF, // 12 - Max Averaging Interval
+		0xFFFFFFFF, // 13 - Min Averaging Interval
+		0x40, // 14 - Battery Capacity Granularity 1
+		0x40, // 15 - Battery Capacity Granularity 2
+		" ", // 16 - Model Number
+		" ", // 17 - Serial Number
+		" ", // 18 - Battery Type
+		" " // 19 - OEM Information
+	})
+
+	Method (IVBX, 0, NotSerialized)
+	{
+		PBIX [2] = 0xFFFFFFFF
+		PBIX [3] = 0xFFFFFFFF
+		PBIX [5] = 0xFFFFFFFF
+		PBIX [16] = " "
+		PBIX [17] = " "
+		PBIX [18] = " "
+		PBIX [19] = " "
+		BFCC = Zero
+	}
+
+	Method (UPBX, 0, NotSerialized)
+	{
+		If (^^PCI0.LPCB.EC0.BAT0)
+		{
+			Local0 = (^^PCI0.LPCB.EC0.BDC0 & 0xFFFF)
+			PBIX [2] = Local0
+			Local0 = (^^PCI0.LPCB.EC0.BFC0 & 0xFFFF)
+			PBIX [3] = Local0
+			BFCC = Local0
+			Local0 = (^^PCI0.LPCB.EC0.BDV0 & 0xFFFF)
+			PBIX [5] = Local0
+			Local0 = (^^PCI0.LPCB.EC0.BCW0 & 0xFFFF)
+			PBIX [6] = Local0
+			Local0 = (^^PCI0.LPCB.EC0.BCL0 & 0xFFFF)
+			PBIX [7] = Local0
+			LOCAL0 = ^^PCI0.LPCB.EC0.CYC0
+			PBIX [8] = LOCAL0
+			PBIX [16] = "BAT"
+			PBIX [17] = "0001"
+			PBIX [18] = "LION"
+			PBIX [19] = "Notebook"
+		}
+		Else
+		{
+			IVBX ()
+		}
+	}
+
+	Method (_BIX, 0, NotSerialized)  // _BIX: Battery Information Extended
+	{
+		If (^^PCI0.LPCB.EC0.ECOK)
+		{
+			UPBX ()
+		}
+		Else
+		{
+			IVBX ()
+		}
+		Return (PBIX) /* \_SB_.BAT0.PBIX */
+	}
+
 	Name (PBST, Package (0x04)
 	{
 		Zero, // 0 - Battery state

--- a/src/ec/system76/ec/acpi/ec_ram.asl
+++ b/src/ec/system76/ec/acpi/ec_ram.asl
@@ -28,6 +28,7 @@ Field (ERAM, ByteAcc, Lock, Preserve)
 	Offset (0x3A),
 	BCW0, 32,
 	BCL0, 32,
+	CYC0, 16,	// Battery cycle count
 	Offset (0x68),
 	ECOS, 8,	// Detected OS, 0 = no ACPI, 1 = ACPI but no driver, 2 = ACPI with driver
 	Offset (0xC8),


### PR DESCRIPTION
After noticing that cycle count wasn't reported with our firmware (after seeing https://gitlab.freedesktop.org/upower/upower/-/issues/152), I thought I'd see what it takes to implement and try to better understand how this works at a firmware level.

Not sure exactly what value to expect, but `/sys/class/power_supply/BAT0/cycle_count` reports a non-zero value now, and draining my battery made it go up by one, so it seems to be working.

Requires https://github.com/system76/ec/pull/243.