### PR TITLE
soc/intel/tigerlake: Add values for GMA registers

### DIFF
--- a/src/soc/intel/tigerlake/Kconfig
+++ b/src/soc/intel/tigerlake/Kconfig
@@ -258,6 +258,18 @@ config EARLY_TCSS_DISPLAY
 	help
 	  Enable displays to be detected over Type-C ports during boot.
 
+config INTEL_GMA_BCLV_OFFSET
+	default 0xc8258
+
+config INTEL_GMA_BCLV_WIDTH
+	default 32
+
+config INTEL_GMA_BCLM_OFFSET
+	default 0xc8254
+
+config INTEL_GMA_BCLM_WIDTH
+	default 32
+
 config DISABLE_ME
 	bool "Disable the IME by setting the HAP bit at run-time"
 	# XXX: Prevents CPU from reaching C10


### PR DESCRIPTION
Fix backlight controls on TGL?

Checked with `intel_reg` on gaze16 when using `default_brightness_table.asl`.

```
$ sudo intel_reg read 0xc8254
            (0x000c8254): 0x0000bb80 (freq 0, cycle 48000)
$ cat /sys/class/backlight/intel_backlight/max_brightness 
48000
```
```
# At 20% brightness
$ sudo intel_reg read 0xc8258
            (0x000c8258): 0x0000102d
$ cat /sys/class/backlight/intel_backlight/brightness 
1399

# At 50% brightness
$ sudo intel_reg read 0xc8258
            (0x000c8258): 0x00005d62
$ cat /sys/class/backlight/intel_backlight/brightness 
22400
```

upstream: [CB:57823](https://review.coreboot.org/c/coreboot/+/57823)