### PR TITLE
mb/system76/gaze16: Enable TCSS xHCI

### DIFF
--- a/src/mainboard/system76/gaze16/devicetree.cb
+++ b/src/mainboard/system76/gaze16/devicetree.cb
@@ -118,6 +118,9 @@ chip soc/intel/tigerlake
 			register "Device4Enable" = "1"
 		end
 		device ref gna on end
+		device ref north_xhci on
+			register "TcssXhciEn" = "1"
+		end
 
 		# From PCH EDS(615985)
 		device ref cnvi_bt on end


### PR DESCRIPTION
Fix using USB 2.0 devices via an adapter in the Type-C port.

Resolves: system76/firmware-open#242