### PR TITLE
mb/system76/lemp10: Fix memory info

### DIFF
--- a/src/mainboard/system76/lemp10/romstage.c
+++ b/src/mainboard/system76/lemp10/romstage.c
@@ -13,7 +13,6 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 		.topo = MEM_TOPO_MIXED,
 		.cbfs_index = 0,
 		.smbus = {
-			[0] = { .addr_dimm[0] = 0x50, },
 			[1] = { .addr_dimm[0] = 0x52, },
 		},
 	};


### PR DESCRIPTION
The Lemur Pro, with its mixed memory topology, only has a DIMM at address 0x52.
