### PR TITLE
soc/intel/common/memory: Don't die if SPD lengths differ

### DIFF
--- a/src/soc/intel/common/block/memory/meminit.c
+++ b/src/soc/intel/common/block/memory/meminit.c
@@ -164,7 +164,8 @@ void mem_populate_channel_data(const struct soc_mem_cfg *soc_mem_cfg,
 		 * topology.
 		 */
 		if (spd_md_len != spd_dimm_len)
-			die("Length of SPD does not match for mixed topology!\n");
+			printk(BIOS_ERR, "Mixed topology has incorrect length: %d != %d\n",
+			       (int)spd_md_len, (int)spd_dimm_len);
 
 		data->spd_len = spd_md_len;
 	}


### PR DESCRIPTION
Revert from `die()` to `printk()` if SPD lengths are different for mixed memory topology. Fixes booting system76/lemp10 when a DIMM is not present.

Resolves: system76/firmware-open#269

---

On `system76-4.13` the DIMM SPD size would get detected as 256 when not present.

> No memory dimm at address A4
> Mixed topology has incorrect length: 512 != 256.
