### PR TITLE
mb/system76: tgl-u: Disable RTD3 on CPU PCIe RP

### DIFF
--- a/src/mainboard/system76/darp7/devicetree.cb
+++ b/src/mainboard/system76/darp7/devicetree.cb
@@ -112,13 +112,15 @@ chip soc/intel/tigerlake
 			# PCIe PEG0 x4, Clock 0 (SSD1)
 			register "PcieClkSrcUsage[0]" = "0x40"
 			register "PcieClkSrcClkReq[0]" = "0"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_B16)" # SSD1_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_D13)" # GPP_D13_SSD1_PLT_RST#
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
+			# Causes errors on suspend: device can't reach D0 after s2idle
+			# TODO: Test with coreboot 4.16, which has SrcClk and ModPHY implemented
+			#chip soc/intel/common/block/pcie/rtd3
+			#	register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_B16)" # SSD1_PWR_EN
+			#	register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_D13)" # GPP_D13_SSD1_PLT_RST#
+			#	# TODO: Support disable/enable CPU RP clock
+			#	register "srcclk_pin" = "0" # SSD1_CLKREQ#
+			#	device generic 0 on end
+			#end
 		end
 		device ref tbt_pcie_rp0 on end # J_TYPEC2
 		device ref north_xhci on # J_TYPEC2

--- a/src/mainboard/system76/galp5/devicetree.cb
+++ b/src/mainboard/system76/galp5/devicetree.cb
@@ -112,13 +112,15 @@ chip soc/intel/tigerlake
 			# PCIe PEG0 x4, Clock 0 (SSD1)
 			register "PcieClkSrcUsage[0]" = "0x40"
 			register "PcieClkSrcClkReq[0]" = "0"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD1_PWR_DN#
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_H0)" # GPP_H0_RTD3
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
+			# Causes errors on suspend: device can't reach D0 after s2idle
+			# TODO: Test with coreboot 4.16, which has SrcClk and ModPHY implemented
+			#chip soc/intel/common/block/pcie/rtd3
+			#	register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD1_PWR_DN#
+			#	register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_H0)" # GPP_H0_RTD3
+			#	# TODO: Support disable/enable CPU RP clock
+			#	register "srcclk_pin" = "0" # SSD1_CLKREQ#
+			#	device generic 0 on end
+			#end
 		end
 		device ref tbt_pcie_rp0 on end # J_TYPEC2
 		device ref gna on end

--- a/src/mainboard/system76/lemp10/devicetree.cb
+++ b/src/mainboard/system76/lemp10/devicetree.cb
@@ -113,13 +113,15 @@ chip soc/intel/tigerlake
 			# Despite the name, SSD2_CLKREQ# is used for SSD1
 			register "PcieClkSrcUsage[3]" = "0x40"
 			register "PcieClkSrcClkReq[3]" = "3"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C13)" # SSD1_PWR_DN#
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_C22)" # GPP_C12_RTD3 (labeled incorrectly)
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # SSD2_CLKREQ#
-				device generic 0 on end
-			end
+			# Causes errors on suspend: device can't reach D0 after s2idle
+			# TODO: Test with coreboot 4.16, which has SrcClk and ModPHY implemented
+			#chip soc/intel/common/block/pcie/rtd3
+			#	register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C13)" # SSD1_PWR_DN#
+			#	register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_C22)" # GPP_C12_RTD3 (labeled incorrectly)
+			#	# TODO: Support disable/enable CPU RP clock
+			#	register "srcclk_pin" = "3" # SSD2_CLKREQ#
+			#	device generic 0 on end
+			#end
 		end
 		device ref tbt_pcie_rp0 on end # J_TYPEC1
 		device ref gna on end


### PR DESCRIPTION
Revert enabling RTD3 for the CPU PCIe RP, as it prevents the NVMe drive from reaching D0 after D3cold.