### PR TITLE
mb/system76/gaze15: Set `_UID` for touchpad devices

### DIFF
--- a/src/mainboard/system76/gaze15/variants/gaze15/overridetree.cb
+++ b/src/mainboard/system76/gaze15/variants/gaze15/overridetree.cb
@@ -13,6 +13,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""ELAN Touchpad""
+				register "generic.uid" = "0"
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x01"
@@ -21,6 +22,7 @@ chip soc/intel/cannonlake
 			chip drivers/i2c/hid
 				register "generic.hid" = ""PNP0C50""
 				register "generic.desc" = ""Synaptics Touchpad""
+				register "generic.uid" = "1"
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"


### PR DESCRIPTION
Upstream: [CB:61210](https://review.coreboot.org/c/coreboot/+/61210)

The `_UID` must be unique as these devices use the same `_HID`. Fixes BSOD when booting Windows.

Ref: system76/firmware-open#284