### PR TITLE
Full support for RTD3 on CPU PCIe RPs

### DIFF
--- a/src/include/acpi/acpigen.h
+++ b/src/include/acpi/acpigen.h
@@ -298,6 +298,8 @@ struct cppc_config {
 	cppc_entry_t entries[CPPC_MAX_FIELDS_VER_3];
 };
 
+#define ACPI_MUTEX_NO_TIMEOUT		0xffff
+
 void acpigen_write_return_integer(uint64_t arg);
 void acpigen_write_return_namestr(const char *arg);
 void acpigen_write_return_string(const char *arg);

--- a/src/mainboard/system76/darp7/devicetree.cb
+++ b/src/mainboard/system76/darp7/devicetree.cb
@@ -115,8 +115,7 @@ chip soc/intel/tigerlake
 			chip soc/intel/common/block/pcie/rtd3
 				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_B16)" # SSD1_PWR_EN
 				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_D13)" # GPP_D13_SSD1_PLT_RST#
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # SSD1_CLKREQ#
+				register "srcclk_pin" = "0" # SSD1_CLKREQ#
 				device generic 0 on end
 			end
 		end

--- a/src/mainboard/system76/galp5/devicetree.cb
+++ b/src/mainboard/system76/galp5/devicetree.cb
@@ -115,8 +115,7 @@ chip soc/intel/tigerlake
 			chip soc/intel/common/block/pcie/rtd3
 				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD1_PWR_DN#
 				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_H0)" # GPP_H0_RTD3
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # SSD1_CLKREQ#
+				register "srcclk_pin" = "0" # SSD1_CLKREQ#
 				device generic 0 on end
 			end
 		end

--- a/src/mainboard/system76/gaze16/variants/3050/overridetree.cb
+++ b/src/mainboard/system76/gaze16/variants/3050/overridetree.cb
@@ -13,8 +13,7 @@ chip soc/intel/tigerlake
 				register "enable_off_delay_ms" = "4"
 				register "reset_delay_ms" = "10"
 				register "reset_off_delay_ms" = "4"
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # GFX_CLKREQ0#
+				register "srcclk_pin" = "0" # GFX_CLKREQ0#
 				device generic 0 on end
 			end
 

--- a/src/mainboard/system76/gaze16/variants/3060/overridetree.cb
+++ b/src/mainboard/system76/gaze16/variants/3060/overridetree.cb
@@ -13,8 +13,7 @@ chip soc/intel/tigerlake
 				register "enable_off_delay_ms" = "4"
 				register "reset_delay_ms" = "10"
 				register "reset_off_delay_ms" = "4"
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # PEG_CLKREQ#
+				register "srcclk_pin" = "9" # PEG_CLKREQ#
 				device generic 0 on end
 			end
 

--- a/src/mainboard/system76/lemp10/devicetree.cb
+++ b/src/mainboard/system76/lemp10/devicetree.cb
@@ -116,8 +116,7 @@ chip soc/intel/tigerlake
 			chip soc/intel/common/block/pcie/rtd3
 				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C13)" # SSD1_PWR_DN#
 				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_C22)" # GPP_C12_RTD3 (labeled incorrectly)
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # SSD2_CLKREQ#
+				register "srcclk_pin" = "3" # SSD2_CLKREQ#
 				device generic 0 on end
 			end
 		end

--- a/src/mainboard/system76/oryp8/devicetree.cb
+++ b/src/mainboard/system76/oryp8/devicetree.cb
@@ -99,8 +99,7 @@ chip soc/intel/tigerlake
 				register "enable_off_delay_ms" = "4"
 				register "reset_delay_ms" = "10"
 				register "reset_off_delay_ms" = "4"
-				# TODO: Support disable/enable CPU RP clock
-				register "srcclk_pin" = "-1" # PEG_CLKREQ#
+				register "srcclk_pin" = "9" # PEG_CLKREQ#
 				device generic 0 on end
 			end
 

--- a/src/soc/intel/alderlake/romstage/fsp_params.c
+++ b/src/soc/intel/alderlake/romstage/fsp_params.c
@@ -22,11 +22,6 @@
 
 #define CPU_PCIE_BASE			0x40
 
-enum pcie_rp_type {
-	PCH_PCIE_RP,
-	CPU_PCIE_RP,
-};
-
 enum vtd_base_index_type {
 	VTD_GFX,
 	VTD_IPU,
@@ -39,11 +34,11 @@ enum vtd_base_index_type {
 
 static uint8_t clk_src_to_fsp(enum pcie_rp_type type, int rp_number)
 {
-	assert(type == PCH_PCIE_RP || type == CPU_PCIE_RP);
+	assert(type == PCIE_RP_PCH || type == PCIE_RP_CPU);
 
-	if (type == PCH_PCIE_RP)
+	if (type == PCIE_RP_PCH)
 		return rp_number;
-	else // type == CPU_PCIE_RP
+	else // type == PCIE_RP_CPU
 		return CPU_PCIE_BASE + rp_number;
 }
 
@@ -81,12 +76,12 @@ static void fill_fspm_pcie_rp_params(FSP_M_CONFIG *m_cfg,
 
 	/* Configure PCH PCIE ports */
 	m_cfg->PcieRpEnableMask = pcie_rp_enable_mask(get_pch_pcie_rp_table());
-	pcie_rp_init(m_cfg, m_cfg->PcieRpEnableMask, PCH_PCIE_RP, config->pch_pcie_rp,
+	pcie_rp_init(m_cfg, m_cfg->PcieRpEnableMask, PCIE_RP_PCH, config->pch_pcie_rp,
 			CONFIG_MAX_PCH_ROOT_PORTS);
 
 	/* Configure CPU PCIE ports */
 	m_cfg->CpuPcieRpEnableMask = pcie_rp_enable_mask(get_cpu_pcie_rp_table());
-	pcie_rp_init(m_cfg, m_cfg->CpuPcieRpEnableMask, CPU_PCIE_RP, config->cpu_pcie_rp,
+	pcie_rp_init(m_cfg, m_cfg->CpuPcieRpEnableMask, PCIE_RP_CPU, config->cpu_pcie_rp,
 			CONFIG_MAX_CPU_ROOT_PORTS);
 }
 

--- a/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
+++ b/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
@@ -111,4 +111,10 @@ void pcie_rp_update_devicetree(const struct pcie_rp_group *groups);
  */
 uint32_t pcie_rp_enable_mask(const struct pcie_rp_group *groups);
 
+enum pcie_rp_type {
+	PCIE_RP_UNKNOWN,
+	PCIE_RP_CPU,
+	PCIE_RP_PCH,
+};
+
 #endif /* SOC_INTEL_COMMON_BLOCK_PCIE_RP_H */

--- a/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
+++ b/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
@@ -121,4 +121,7 @@ enum pcie_rp_type {
 struct device; /* Not necessary to include all of device/device.h */
 enum pcie_rp_type soc_get_pcie_rp_type(const struct device *dev);
 
+/* Return the virtual wire index that represents CPU-side PCIe root ports */
+int soc_get_cpu_rp_vw_idx(const struct device *dev);
+
 #endif /* SOC_INTEL_COMMON_BLOCK_PCIE_RP_H */

--- a/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
+++ b/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
@@ -117,4 +117,8 @@ enum pcie_rp_type {
 	PCIE_RP_PCH,
 };
 
+/* For PCIe RTD3 support, each SoC that uses it must implement this function. */
+struct device; /* Not necessary to include all of device/device.h */
+enum pcie_rp_type soc_get_pcie_rp_type(const struct device *dev);
+
 #endif /* SOC_INTEL_COMMON_BLOCK_PCIE_RP_H */

--- a/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
+++ b/src/soc/intel/common/block/include/intelblocks/pcie_rp.h
@@ -111,6 +111,9 @@ void pcie_rp_update_devicetree(const struct pcie_rp_group *groups);
  */
 uint32_t pcie_rp_enable_mask(const struct pcie_rp_group *groups);
 
+/* Get PCH root port groups */
+const struct pcie_rp_group *soc_get_pch_rp_groups(void);
+
 enum pcie_rp_type {
 	PCIE_RP_UNKNOWN,
 	PCIE_RP_CPU,

--- a/src/soc/intel/common/block/pcie/rtd3/rtd3.c
+++ b/src/soc/intel/common/block/pcie/rtd3/rtd3.c
@@ -9,6 +9,8 @@
 #include <device/pci.h>
 #include <intelblocks/pmc.h>
 #include <intelblocks/pmc_ipc.h>
+#include <intelblocks/pcie_rp.h>
+#include <soc/iomap.h>
 #include "chip.h"
 
 /*
@@ -42,6 +44,14 @@
 #define ACPI_REG_PCI_L23_RDY_DETECT "L23R" /* L23_Rdy Detect Transition */
 #define ACPI_REG_PCI_L23_SAVE_STATE "NCB7" /* Scratch bit to save L23 state */
 
+/* ACPI path to the mutex that protects accesses to PMC ModPhy power gating registers */
+#define RTD3_MUTEX_PATH "\\_SB.PCI0.R3MX"
+
+enum modphy_pg_state {
+	PG_DISABLE = 0,
+	PG_ENABLE = 1,
+};
+
 /* Called from _ON to get PCIe link back to active state. */
 static void pcie_rtd3_acpi_l23_exit(void)
 {
@@ -74,13 +84,34 @@ static void pcie_rtd3_acpi_l23_entry(void)
 	acpigen_write_store_int_to_namestr(1, ACPI_REG_PCI_L23_SAVE_STATE);
 }
 
+/* Called from _ON/_OFF to disable/enable ModPHY power gating */
+static void pcie_rtd3_enable_modphy_pg(unsigned int pcie_rp, enum modphy_pg_state state)
+{
+	/* Enter the critical section */
+	acpigen_emit_ext_op(ACQUIRE_OP);
+	acpigen_emit_namestring(RTD3_MUTEX_PATH);
+	acpigen_emit_word(ACPI_MUTEX_NO_TIMEOUT);
+
+	acpigen_write_store_int_to_namestr(state, "EMPG");
+	acpigen_write_delay_until_namestr_int(100, "AMPG", state);
+
+	/* Exit the critical section */
+	acpigen_emit_ext_op(RELEASE_OP);
+	acpigen_emit_namestring(RTD3_MUTEX_PATH);
+}
+
 static void
 pcie_rtd3_acpi_method_on(unsigned int pcie_rp,
-			 const struct soc_intel_common_block_pcie_rtd3_config *config)
+			 const struct soc_intel_common_block_pcie_rtd3_config *config,
+			 enum pcie_rp_type rp_type)
 {
 	acpigen_write_method_serialized("_ON", 0);
 
 	acpigen_write_debug_string("PCIe RTD3 _ON");
+
+	/* Disable modPHY power gating for PCH RPs. */
+	if (rp_type == PCIE_RP_PCH)
+		pcie_rtd3_enable_modphy_pg(pcie_rp, PG_DISABLE);
 
 	/* Assert enable GPIO to turn on device power. */
 	if (config->enable_gpio.pin_count) {
@@ -100,7 +131,7 @@ pcie_rtd3_acpi_method_on(unsigned int pcie_rp,
 			acpigen_write_sleep(config->reset_delay_ms);
 	}
 
-	/* Trigger L23 ready exit flow unless disabld by config. */
+	/* Trigger L23 ready exit flow unless disabled by config. */
 	if (!config->disable_l23)
 		pcie_rtd3_acpi_l23_exit();
 
@@ -109,7 +140,8 @@ pcie_rtd3_acpi_method_on(unsigned int pcie_rp,
 
 static void
 pcie_rtd3_acpi_method_off(int pcie_rp,
-			  const struct soc_intel_common_block_pcie_rtd3_config *config)
+			  const struct soc_intel_common_block_pcie_rtd3_config *config,
+			  enum pcie_rp_type rp_type)
 {
 	acpigen_write_method_serialized("_OFF", 0);
 
@@ -125,6 +157,10 @@ pcie_rtd3_acpi_method_off(int pcie_rp,
 		if (config->reset_off_delay_ms)
 			acpigen_write_sleep(config->reset_off_delay_ms);
 	}
+
+	/* Enable modPHY power gating for PCH RPs */
+	if (rp_type == PCIE_RP_PCH)
+		pcie_rtd3_enable_modphy_pg(pcie_rp, PG_ENABLE);
 
 	/* Disable SRCCLK for this root port if pin is defined. */
 	if (config->srcclk_pin >= 0)
@@ -169,8 +205,31 @@ pcie_rtd3_acpi_method_status(int pcie_rp,
 	acpigen_pop_len(); /* Method */
 }
 
+static void write_modphy_opregion(unsigned int pcie_rp)
+{
+	/* The register containing the Power Gate enable sequence bits is at
+	   PCH_PWRM_BASE + 0x10D0, and the bits to check for sequence completion are at
+	   PCH_PWRM_BASE + 0x10D4. */
+	const struct opregion opregion = OPREGION("PMCP", SYSTEMMEMORY,
+						  PCH_PWRM_BASE_ADDRESS + 0x1000, 0xff);
+	const struct fieldlist fieldlist[] = {
+		FIELDLIST_OFFSET(0xD0),
+		FIELDLIST_RESERVED(pcie_rp),
+		FIELDLIST_NAMESTR("EMPG", 1),	/* Enable ModPHY Power Gate */
+		FIELDLIST_OFFSET(0xD4),
+		FIELDLIST_RESERVED(pcie_rp),
+		FIELDLIST_NAMESTR("AMPG", 1),	/* Is ModPHY Power Gate active? */
+	};
+
+	acpigen_write_opregion(&opregion);
+	acpigen_write_field("PMCP", fieldlist, ARRAY_SIZE(fieldlist),
+			    FIELD_DWORDACC | FIELD_NOLOCK | FIELD_PRESERVE);
+}
+
 static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 {
+	static bool mutex_created = false;
+
 	const struct soc_intel_common_block_pcie_rtd3_config *config = config_of(dev);
 	static const char *const power_res_states[] = {"_PR0", "_PR3"};
 	const struct device *parent = dev->bus->dev;
@@ -210,6 +269,8 @@ static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 		return;
 	}
 
+	const enum pcie_rp_type rp_type = soc_get_pcie_rp_type(parent);
+
 	/* Read port number of root port that this device is attached to. */
 	pcie_rp = pci_read_config8(parent, PCH_PCIE_CFG_LCAP_PN);
 	if (pcie_rp == 0 || pcie_rp > CONFIG_MAX_ROOT_PORTS) {
@@ -222,21 +283,34 @@ static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 	printk(BIOS_INFO, "%s: Enable RTD3 for %s (%s) on RP #%d\n", scope, dev_path(parent),
 	       config->desc ?: dev->chip_ops->name, pcie_rp + 1);
 
+	/* Create a mutex for exclusive access to the PMC registers. */
+	if (rp_type == PCIE_RP_PCH && !mutex_created) {
+		acpigen_write_scope("\\_SB.PCI0");
+		acpigen_write_mutex("R3MX", 0);
+		acpigen_write_scope_end();
+		mutex_created = true;
+	}
+
 	/* The RTD3 power resource is added to the root port, not the device. */
 	acpigen_write_scope(scope);
 
 	if (config->desc)
 		acpigen_write_name_string("_DDN", config->desc);
 
+	/* Create OpRegions for MMIO accesses. */
 	acpigen_write_opregion(&opregion);
 	acpigen_write_field("PXCS", fieldlist, ARRAY_SIZE(fieldlist),
 			    FIELD_ANYACC | FIELD_NOLOCK | FIELD_PRESERVE);
 
+	/* Create the OpRegion to access the ModPHY PG registers (PCH RPs only) */
+	if (rp_type == PCIE_RP_PCH)
+		write_modphy_opregion(pcie_rp);
+
 	/* ACPI Power Resource for controlling the attached device power. */
 	acpigen_write_power_res("RTD3", 0, 0, power_res_states, ARRAY_SIZE(power_res_states));
 	pcie_rtd3_acpi_method_status(pcie_rp, config);
-	pcie_rtd3_acpi_method_on(pcie_rp, config);
-	pcie_rtd3_acpi_method_off(pcie_rp, config);
+	pcie_rtd3_acpi_method_on(pcie_rp, config, rp_type);
+	pcie_rtd3_acpi_method_off(pcie_rp, config, rp_type);
 	acpigen_pop_len(); /* PowerResource */
 
 	/* Indicate to the OS that device supports hotplug in D3. */

--- a/src/soc/intel/common/block/pcie/rtd3/rtd3.c
+++ b/src/soc/intel/common/block/pcie/rtd3/rtd3.c
@@ -177,8 +177,7 @@ pcie_rtd3_acpi_method_off(int pcie_rp,
 }
 
 static void
-pcie_rtd3_acpi_method_status(int pcie_rp,
-			     const struct soc_intel_common_block_pcie_rtd3_config *config)
+pcie_rtd3_acpi_method_status(const struct soc_intel_common_block_pcie_rtd3_config *config)
 {
 	const struct acpi_gpio *gpio;
 
@@ -226,6 +225,29 @@ static void write_modphy_opregion(unsigned int pcie_rp)
 			    FIELD_DWORDACC | FIELD_NOLOCK | FIELD_PRESERVE);
 }
 
+static int get_pcie_rp_pmc_idx(enum pcie_rp_type rp_type, const struct device *dev)
+{
+	int idx = -1;
+
+	switch (rp_type) {
+	case PCIE_RP_PCH:
+		/* Read port number of root port that this device is attached to. */
+		idx = pci_read_config8(dev, PCH_PCIE_CFG_LCAP_PN);
+
+		/* Port number is 1-based, PMC IPC method expects 0-based. */
+		idx--;
+		break;
+	case PCIE_RP_CPU:
+		/* CPU RPs are indexed by their "virtual wire index" to the PCH */
+		idx = soc_get_cpu_rp_vw_idx(dev);
+		break;
+	default:
+		break;
+	}
+
+	return idx;
+}
+
 static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 {
 	static bool mutex_created = false;
@@ -247,7 +269,7 @@ static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 		FIELDLIST_NAMESTR(ACPI_REG_PCI_L23_RDY_ENTRY, 1),
 		FIELDLIST_NAMESTR(ACPI_REG_PCI_L23_RDY_DETECT, 1),
 	};
-	uint8_t pcie_rp;
+	int pcie_rp;
 	struct acpi_dp *dsd, *pkg;
 
 	if (!is_dev_enabled(parent)) {
@@ -270,15 +292,11 @@ static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 	}
 
 	const enum pcie_rp_type rp_type = soc_get_pcie_rp_type(parent);
-
-	/* Read port number of root port that this device is attached to. */
-	pcie_rp = pci_read_config8(parent, PCH_PCIE_CFG_LCAP_PN);
-	if (pcie_rp == 0 || pcie_rp > CONFIG_MAX_ROOT_PORTS) {
-		printk(BIOS_ERR, "%s: Invalid root port number: %u\n", __func__, pcie_rp);
+	pcie_rp = get_pcie_rp_pmc_idx(rp_type, parent);
+	if (pcie_rp < 0 || pcie_rp > CONFIG_MAX_ROOT_PORTS) {
+		printk(BIOS_ERR, "%s: Unknown PCIe root port\n", __func__);
 		return;
 	}
-	/* Port number is 1-based, PMC IPC method expects 0-based. */
-	pcie_rp--;
 
 	printk(BIOS_INFO, "%s: Enable RTD3 for %s (%s) on RP #%d\n", scope, dev_path(parent),
 	       config->desc ?: dev->chip_ops->name, pcie_rp + 1);
@@ -308,7 +326,7 @@ static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 
 	/* ACPI Power Resource for controlling the attached device power. */
 	acpigen_write_power_res("RTD3", 0, 0, power_res_states, ARRAY_SIZE(power_res_states));
-	pcie_rtd3_acpi_method_status(pcie_rp, config);
+	pcie_rtd3_acpi_method_status(config);
 	pcie_rtd3_acpi_method_on(pcie_rp, config, rp_type);
 	pcie_rtd3_acpi_method_off(pcie_rp, config, rp_type);
 	acpigen_pop_len(); /* PowerResource */

--- a/src/soc/intel/common/block/pcie/rtd3/rtd3.c
+++ b/src/soc/intel/common/block/pcie/rtd3/rtd3.c
@@ -293,7 +293,7 @@ static void pcie_rtd3_acpi_fill_ssdt(const struct device *dev)
 
 	const enum pcie_rp_type rp_type = soc_get_pcie_rp_type(parent);
 	pcie_rp = get_pcie_rp_pmc_idx(rp_type, parent);
-	if (pcie_rp < 0 || pcie_rp > CONFIG_MAX_ROOT_PORTS) {
+	if (pcie_rp < 0) {
 		printk(BIOS_ERR, "%s: Unknown PCIe root port\n", __func__);
 		return;
 	}

--- a/src/soc/intel/tigerlake/Makefile.inc
+++ b/src/soc/intel/tigerlake/Makefile.inc
@@ -34,6 +34,7 @@ ramstage-y += lockdown.c
 ramstage-y += lpm.c
 ramstage-y += me.c
 ramstage-y += p2sb.c
+ramstage-y += pcie_rp.c
 ramstage-y += pmc.c
 ramstage-y += reset.c
 ramstage-y += soundwire.c

--- a/src/soc/intel/tigerlake/chip.c
+++ b/src/soc/intel/tigerlake/chip.c
@@ -17,19 +17,6 @@
 #include <soc/ramstage.h>
 #include <soc/soc_chip.h>
 
-static const struct pcie_rp_group pch_lp_rp_groups[] = {
-	{ .slot = PCH_DEV_SLOT_PCIE,	.count = 8 },
-	{ .slot = PCH_DEV_SLOT_PCIE_1,	.count = 4 },
-	{ 0 }
-};
-
-static const struct pcie_rp_group pch_h_rp_groups[] = {
-	{ .slot = PCH_DEV_SLOT_PCIE,	.count = 8 },
-	{ .slot = PCH_DEV_SLOT_PCIE_1,	.count = 8 },
-	{ .slot = PCH_DEV_SLOT_PCIE_2,	.count = 8 },
-	{ 0 }
-};
-
 #if CONFIG(HAVE_ACPI_TABLES)
 const char *soc_acpi_name(const struct device *dev)
 {
@@ -170,10 +157,8 @@ void soc_init_pre_device(void *chip_info)
 	soc_fill_gpio_pm_configuration();
 
 	/* Swap enabled PCI ports in device tree if needed. */
-	if (CONFIG(SOC_INTEL_TIGERLAKE_PCH_H))
-		pcie_rp_update_devicetree(pch_h_rp_groups);
-	else
-		pcie_rp_update_devicetree(pch_lp_rp_groups);
+	const struct pcie_rp_group *pch_rp_groups = soc_get_pch_rp_groups();
+	pcie_rp_update_devicetree(pch_rp_groups);
 }
 
 static void cpu_fill_ssdt(const struct device *dev)

--- a/src/soc/intel/tigerlake/pcie_rp.c
+++ b/src/soc/intel/tigerlake/pcie_rp.c
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <device/device.h>
+#include <intelblocks/pcie_rp.h>
+#include <soc/pci_devs.h>
+
+static const struct pcie_rp_group pch_lp_rp_groups[] = {
+	{ .slot = PCH_DEV_SLOT_PCIE,	.count = 8 },
+	{ .slot = PCH_DEV_SLOT_PCIE_1,	.count = 8 },
+	{ .slot = PCH_DEV_SLOT_PCIE_2,	.count = 4 },
+	{ 0 }
+};
+
+static const struct pcie_rp_group cpu_rp_groups[] = {
+	{ .slot = SA_DEV_SLOT_PEG,	.start = 0, .count = 3 },
+	{ .slot = SA_DEV_SLOT_CPU_PCIE,	.start = 0, .count = 1 },
+	{ 0 }
+};
+
+static bool is_part_of_group(const struct device *dev,
+			     const struct pcie_rp_group *groups)
+{
+	if (dev->path.type != DEVICE_PATH_PCI)
+		return false;
+
+	const unsigned int slot_to_find = PCI_SLOT(dev->path.pci.devfn);
+	const unsigned int fn_to_find = PCI_FUNC(dev->path.pci.devfn);
+	const struct pcie_rp_group *group;
+	unsigned int i;
+	unsigned int fn;
+
+	for (group = groups; group->count; ++group) {
+		for (i = 0, fn = rp_start_fn(group); i < group->count; i++, fn++) {
+			if (slot_to_find == group->slot && fn_to_find == fn)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+enum pcie_rp_type soc_get_pcie_rp_type(const struct device *dev)
+{
+	if (is_part_of_group(dev, pch_lp_rp_groups))
+		return PCIE_RP_PCH;
+
+	if (is_part_of_group(dev, cpu_rp_groups))
+		return PCIE_RP_CPU;
+
+	return PCIE_RP_UNKNOWN;
+}

--- a/src/soc/intel/tigerlake/pcie_rp.c
+++ b/src/soc/intel/tigerlake/pcie_rp.c
@@ -4,6 +4,8 @@
 #include <intelblocks/pcie_rp.h>
 #include <soc/pci_devs.h>
 
+#define CPU_CPIE_VW_IDX_BASE		24
+
 static const struct pcie_rp_group pch_lp_rp_groups[] = {
 	{ .slot = PCH_DEV_SLOT_PCIE,	.count = 8 },
 	{ .slot = PCH_DEV_SLOT_PCIE_1,	.count = 8 },
@@ -48,4 +50,23 @@ enum pcie_rp_type soc_get_pcie_rp_type(const struct device *dev)
 		return PCIE_RP_CPU;
 
 	return PCIE_RP_UNKNOWN;
+}
+
+int soc_get_cpu_rp_vw_idx(const struct device *dev)
+{
+	if (dev->path.type != DEVICE_PATH_PCI)
+		return -1;
+
+	switch (dev->path.pci.devfn) {
+	case SA_DEVFN_PEG1:
+		return CPU_CPIE_VW_IDX_BASE + 2;
+	case SA_DEVFN_PEG2:
+		return CPU_CPIE_VW_IDX_BASE + 1;
+	case SA_DEVFN_PEG3:
+		return CPU_CPIE_VW_IDX_BASE;
+	case SA_DEVFN_CPU_PCIE:
+		return CPU_CPIE_VW_IDX_BASE + 3;
+	default:
+		return -1;
+	}
 }

--- a/src/soc/intel/tigerlake/pcie_rp.c
+++ b/src/soc/intel/tigerlake/pcie_rp.c
@@ -13,6 +13,13 @@ static const struct pcie_rp_group pch_lp_rp_groups[] = {
 	{ 0 }
 };
 
+static const struct pcie_rp_group pch_h_rp_groups[] = {
+	{ .slot = PCH_DEV_SLOT_PCIE,	.count = 8 },
+	{ .slot = PCH_DEV_SLOT_PCIE_1,	.count = 8 },
+	{ .slot = PCH_DEV_SLOT_PCIE_2,	.count = 8 },
+	{ 0 }
+};
+
 static const struct pcie_rp_group cpu_rp_groups[] = {
 	{ .slot = SA_DEV_SLOT_PEG,	.start = 0, .count = 3 },
 	{ .slot = SA_DEV_SLOT_CPU_PCIE,	.start = 0, .count = 1 },
@@ -41,9 +48,19 @@ static bool is_part_of_group(const struct device *dev,
 	return false;
 }
 
+const struct pcie_rp_group *soc_get_pch_rp_groups(void)
+{
+	if (CONFIG(SOC_INTEL_TIGERLAKE_PCH_H))
+		return pch_h_rp_groups;
+	else
+		return pch_lp_rp_groups;
+}
+
 enum pcie_rp_type soc_get_pcie_rp_type(const struct device *dev)
 {
-	if (is_part_of_group(dev, pch_lp_rp_groups))
+	const struct pcie_rp_group *pch_rp_groups = soc_get_pch_rp_groups();
+
+	if (is_part_of_group(dev, pch_rp_groups))
 		return PCIE_RP_PCH;
 
 	if (is_part_of_group(dev, cpu_rp_groups))


### PR DESCRIPTION
Cherry-pick commits to complete the RTD3 support for CPU RPs.

Also includes ModPHY power gating for addition power savings.

May let us keep RTD3 while fixing:

- system76/firmware-open#278
- system76/firmware-open#282
