### PR TITLE
mb/system76: TGL-U: Do GPIO config after SiliconInit

### DIFF
--- a/src/mainboard/system76/tgl-u/Makefile.inc
+++ b/src/mainboard/system76/tgl-u/Makefile.inc
@@ -6,7 +6,7 @@ bootblock-y += variants/$(VARIANT_DIR)/gpio_early.c
 
 romstage-y += variants/$(VARIANT_DIR)/romstage.c
 
-ramstage-y += ramstage.c
+ramstage-y += variants/$(VARIANT_DIR)/ramstage.c
 ramstage-y += variants/$(VARIANT_DIR)/gpio.c
 ramstage-y += variants/$(VARIANT_DIR)/hda_verb.c
 

--- a/src/mainboard/system76/tgl-u/ramstage.c
+++ b/src/mainboard/system76/tgl-u/ramstage.c
@@ -6,6 +6,13 @@
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {
 	params->CpuPcieRpAdvancedErrorReporting[0] = 0;
+}
 
+static void mainboard_init(void *chip_info)
+{
 	mainboard_configure_gpios();
 }
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/tgl-u/variants/darp7/ramstage.c
+++ b/src/mainboard/system76/tgl-u/variants/darp7/ramstage.c
@@ -5,7 +5,14 @@
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {
+	// CPU RP Config
 	params->CpuPcieRpAdvancedErrorReporting[0] = 0;
+	params->CpuPcieRpLtrEnable[0] = 1;
+	params->CpuPcieRpPtmEnabled[0] = 0;
+
+	// IOM config
+	params->PchUsbOverCurrentEnable = 0;
+	params->PortResetMessageEnable[5] = 1; // J_TYPEC2
 }
 
 static void mainboard_init(void *chip_info)

--- a/src/mainboard/system76/tgl-u/variants/galp5/ramstage.c
+++ b/src/mainboard/system76/tgl-u/variants/galp5/ramstage.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <mainboard/gpio.h>
+#include <soc/ramstage.h>
+
+void mainboard_silicon_init_params(FSP_S_CONFIG *params)
+{
+	// CPU RP Config
+	params->CpuPcieRpAdvancedErrorReporting[0] = 0;
+	params->CpuPcieRpLtrEnable[0] = 1;
+	params->CpuPcieRpPtmEnabled[0] = 0;
+
+	// IOM config
+	params->PchUsbOverCurrentEnable = 0;
+	params->PortResetMessageEnable[5] = 1; // J_TYPEC2
+}
+
+static void mainboard_init(void *chip_info)
+{
+	mainboard_configure_gpios();
+}
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};

--- a/src/mainboard/system76/tgl-u/variants/lemp10/ramstage.c
+++ b/src/mainboard/system76/tgl-u/variants/lemp10/ramstage.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <mainboard/gpio.h>
+#include <soc/ramstage.h>
+
+void mainboard_silicon_init_params(FSP_S_CONFIG *params)
+{
+	// CPU RP Config
+	params->CpuPcieRpAdvancedErrorReporting[0] = 0;
+	params->CpuPcieRpLtrEnable[0] = 1;
+	params->CpuPcieRpPtmEnabled[0] = 0;
+
+	// IOM config
+	params->PchUsbOverCurrentEnable = 0;
+	params->PortResetMessageEnable[2] = 1; // J_TYPEC1
+}
+
+static void mainboard_init(void *chip_info)
+{
+	mainboard_configure_gpios();
+}
+
+struct chip_operations mainboard_ops = {
+	.init = mainboard_init,
+};


### PR DESCRIPTION
Restore `mainboard_ops` to keep behavior of configuring GPIOs after FSP SiliconInit. Also add the change to darp7, which I previously missed.

Fixes: 5783ad7a658f ("mb/system76: TGL-U: Disable AER for CPU PCIe RP")
