### PR TITLE
soc/intel/tgl: Add PEG devices to IRQ constraints

### DIFF
--- a/src/soc/intel/tigerlake/fsp_params.c
+++ b/src/soc/intel/tigerlake/fsp_params.c
@@ -94,6 +94,14 @@ static void parse_devicetree(FSP_S_CONFIG *params)
  */
 static const struct slot_irq_constraints irq_constraints[] = {
 	{
+		.slot = SA_DEV_SLOT_PEG,
+		.fns = {
+			FIXED_INT_PIRQ(SA_DEVFN_PEG1, PCI_INT_A, PIRQ_A),
+			FIXED_INT_PIRQ(SA_DEVFN_PEG2, PCI_INT_B, PIRQ_B),
+			FIXED_INT_PIRQ(SA_DEVFN_PEG3, PCI_INT_C, PIRQ_C),
+		},
+	},
+	{
 		.slot = SA_DEV_SLOT_IGD,
 		.fns = {
 			ANY_PIRQ(SA_DEVFN_IGD),


### PR DESCRIPTION
Fixes IRQ errors on oryp8 that cause conflicts with the PCH HDA device.

```
pcieport 0000:00:01.0: can't derive routing for PCI INT A
pcieport 0000:00:01.0: can't derive routing for PCI INT B
```

```
irq 10: nobody cared (try booting with the "irqpoll" option)
...
[<00000000fb84c354>] azx_interrupt [snd_hda_codec]
Disabling IRQ #10
```

Must be tested on all TGL boards. On TGL-U, these ports are used for the SSD, so SSD slots must be populated.

- [x] darp7
- [x] galp5
- [x] gaze16
- [x] lemp10
- [x] oryp8
