### PR TITLE
mb/system76/adl-p: lemp11: Fix power config

### DIFF
--- a/src/mainboard/system76/adl-p/variants/lemp11/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/lemp11/overridetree.cb
@@ -1,6 +1,6 @@
 chip soc/intel/alderlake
-	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
-		.tdp_pl1_override = 20,
+	register "power_limits_config[ADL_P_142_242_282_15W_CORE]" = "{
+		.tdp_pl1_override = 15,
 		.tdp_pl2_override = 46,
 		.tdp_pl4 = 65,
 	}"


### PR DESCRIPTION
lemp11 is ADL-U, not ADL-P. Use the correct ID to override the values and reduce PL1 to the TDP of 15W.


Check values with cbmem:

```
cd util/cbmem
make
sudo ./cbmem -c > cbmem.txt
grep -E 'CPU (TDP|PL)' cbmem.txt
```

Tested by checking system remains on when:

- Logging in to GDM
- Building firmware-open
- Building the Linux kernel

Which previously could cause an i7 unit to power off.