### PR TITLE
mb/system76: Correct HID names for TP devices

### DIFF
--- a/src/mainboard/system76/addw1/variants/addw1/overridetree.cb
+++ b/src/mainboard/system76/addw1/variants/addw1/overridetree.cb
@@ -9,7 +9,7 @@ chip soc/intel/cannonlake
 		subsystemid 0x1558 0x65d1 inherit
 		device pci 15.0 on      # I2C #0
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_B3_IRQ)"
 				register "generic.probed" = "1"

--- a/src/mainboard/system76/addw1/variants/addw2/overridetree.cb
+++ b/src/mainboard/system76/addw1/variants/addw2/overridetree.cb
@@ -10,7 +10,7 @@ chip soc/intel/cannonlake
 
 		device pci 15.0 on      # I2C #0
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_A14_IRQ)"
 				register "generic.probed" = "1"

--- a/src/mainboard/system76/bonw14/devicetree.cb
+++ b/src/mainboard/system76/bonw14/devicetree.cb
@@ -105,7 +105,7 @@ chip soc/intel/cannonlake
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on      # I2C #0
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"

--- a/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
+++ b/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
@@ -3,7 +3,7 @@ chip soc/intel/cannonlake
 		subsystemid 0x1558 0x1404 inherit
 		device pci 15.0 on
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
 				register "generic.probed" = "1"

--- a/src/mainboard/system76/gaze15/variants/gaze14/overridetree.cb
+++ b/src/mainboard/system76/gaze15/variants/gaze14/overridetree.cb
@@ -11,7 +11,7 @@ chip soc/intel/cannonlake
 
 		device pci 15.0 on      # I2C0
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"

--- a/src/mainboard/system76/gaze15/variants/gaze15/overridetree.cb
+++ b/src/mainboard/system76/gaze15/variants/gaze15/overridetree.cb
@@ -11,18 +11,16 @@ chip soc/intel/cannonlake
 
 		device pci 15.0 on      # I2C0
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""ELAN0412""
 				register "generic.desc" = ""ELAN Touchpad""
-				register "generic.uid" = "0"
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 15 on end
 			end
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
-				register "generic.uid" = "1"
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"
 				register "hid_desc_reg_offset" = "0x20"

--- a/src/mainboard/system76/gaze17/devicetree.cb
+++ b/src/mainboard/system76/gaze17/devicetree.cb
@@ -130,7 +130,7 @@ chip soc/intel/alderlake
 			# Touchpad I2C bus
 			register "serial_io_i2c_mode[PchSerialIoIndexI2C0]" = "PchSerialIoPci"
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""FTCS1000""
 				register "generic.desc" = ""FocalTech Touchpad""
 				register "generic.irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_A17)"
 				register "generic.probed" = "1"

--- a/src/mainboard/system76/oryp6/devicetree.cb
+++ b/src/mainboard/system76/oryp6/devicetree.cb
@@ -106,7 +106,7 @@ chip soc/intel/cannonlake
 		device pci 14.5 off end # SDCard
 		device pci 15.0 on      # I2C #0
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
 				register "generic.probed" = "1"

--- a/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
+++ b/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
@@ -3,7 +3,7 @@ chip soc/intel/cannonlake
 		subsystemid 0x1558 0x1325 inherit
 		device pci 15.0 on
 			chip drivers/i2c/hid
-				register "generic.hid" = ""PNP0C50""
+				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
 				register "generic.probed" = "1"


### PR DESCRIPTION
Use correct HID names instead of CID names for the touchpad. Drop the now unneeded UID for gaze15.

This does not address the TP issue on ADL.

Test: Check Windows doesn't BSOD on gaze15