### PR TITLE
mb/system76/adl-p: darp8: HACK: Limit PL4 to PL2

### DIFF
--- a/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
@@ -1,8 +1,9 @@
 chip soc/intel/alderlake
+	# FIXME: Limit PL4 to PL2 to prevent power off on battery power
 	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
 		.tdp_pl1_override = 20,
 		.tdp_pl2_override = 56,
-		.tdp_pl4 = 65,
+		.tdp_pl4 = 56,
 	}"
 
 	# GPE configuration


### PR DESCRIPTION
Fixes system powering off under load when booting on battery.
