### PR TITLE
mb/system76/adl-p: oryp9: HACK: Further reduce power limits

### DIFF
--- a/src/mainboard/system76/adl-p/variants/oryp9/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/oryp9/overridetree.cb
@@ -3,7 +3,8 @@ chip soc/intel/alderlake
 	# EC will set PL4 on AC adapter plug/unplug
 	register "power_limits_config[ADL_P_642_682_45W_CORE]" = "{
 		.tdp_pl1_override = 45,
-		.tdp_pl2_override = 115,
+		.tdp_pl2_override = 90,
+		.tdp_psyspl2 = 115,
 		.tdp_pl4 = 115,
 	}"
 


### PR DESCRIPTION
System powers off on battery power when building the kernel. Reduce PL2 to 90W (2x TDP; same as oryp8) and limit PsysPL2 to 115W.

Test:

- Build the kernel after booting on battery power