### PR TITLE
mb/system76/adl-p: oryp9: Adjust power limits again

### DIFF
--- a/src/mainboard/system76/adl-p/variants/oryp9/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/oryp9/overridetree.cb
@@ -3,9 +3,9 @@ chip soc/intel/alderlake
 	# EC will set PL4 on AC adapter plug/unplug
 	register "power_limits_config[ADL_P_642_682_45W_CORE]" = "{
 		.tdp_pl1_override = 45,
-		.tdp_pl2_override = 90,
-		.tdp_psyspl2 = 115,
-		.tdp_pl4 = 115,
+		.tdp_pl2_override = 115,
+		.tdp_psyspl2 = 135,
+		.tdp_pl4 = 72,
 	}"
 
 	# Thermal


### PR DESCRIPTION
90W for PL4 still results in power off after booting on battery.

- Limit PL4 to 72W (1.6x TDP)
- Increase PL2 back to coreboot default value of 115W
- Increase PsysPL2 to 135W

Test:

- Compile the kernel while in NVIDIA graphics mode and on battery power
- Benchmark CPU performance