### PR TITLE
mb/system76: Change touchpad detection method

### DIFF
--- a/src/mainboard/system76/addw1/variants/addw1/overridetree.cb
+++ b/src/mainboard/system76/addw1/variants/addw1/overridetree.cb
@@ -12,7 +12,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_B3_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/addw1/variants/addw2/overridetree.cb
+++ b/src/mainboard/system76/addw1/variants/addw2/overridetree.cb
@@ -13,7 +13,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_A14_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/bonw14/devicetree.cb
+++ b/src/mainboard/system76/bonw14/devicetree.cb
@@ -106,7 +106,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
+++ b/src/mainboard/system76/cml-u/variants/darp6/overridetree.cb
@@ -6,7 +6,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/gaze15/variants/gaze14/overridetree.cb
+++ b/src/mainboard/system76/gaze15/variants/gaze14/overridetree.cb
@@ -14,7 +14,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/gaze15/variants/gaze15/overridetree.cb
+++ b/src/mainboard/system76/gaze15/variants/gaze15/overridetree.cb
@@ -14,7 +14,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""ELAN0412""
 				register "generic.desc" = ""ELAN Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 15 on end
 			end
@@ -22,7 +22,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/gaze16/devicetree.cb
+++ b/src/mainboard/system76/gaze16/devicetree.cb
@@ -118,7 +118,7 @@ chip soc/intel/tigerlake
 				register "generic.hid" = ""ELAN0412""
 				register "generic.desc" = ""ELAN Touchpad""
 				register "generic.irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_R12)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 15 on end
 			end

--- a/src/mainboard/system76/lemp9/devicetree.cb
+++ b/src/mainboard/system76/lemp9/devicetree.cb
@@ -94,7 +94,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""ELAN040D""
 				register "generic.desc" = ""ELAN Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_B3_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 15 on end
 			end

--- a/src/mainboard/system76/oryp6/devicetree.cb
+++ b/src/mainboard/system76/oryp6/devicetree.cb
@@ -108,7 +108,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_E7_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/oryp8/devicetree.cb
+++ b/src/mainboard/system76/oryp8/devicetree.cb
@@ -148,7 +148,7 @@ chip soc/intel/tigerlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_R12)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end

--- a/src/mainboard/system76/tgl-u/devicetree.cb
+++ b/src/mainboard/system76/tgl-u/devicetree.cb
@@ -102,7 +102,7 @@ chip soc/intel/tigerlake
 				register "generic.hid" = ""ELAN0412""
 				register "generic.desc" = ""ELAN Touchpad""
 				register "generic.irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_B3)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 15 on end
 			end
@@ -110,7 +110,7 @@ chip soc/intel/tigerlake
 				register "generic.hid" = ""FTCS1000""
 				register "generic.desc" = ""FocalTech Touchpad""
 				register "generic.irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_B3)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 38 on end
 			end

--- a/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
+++ b/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
@@ -6,7 +6,7 @@ chip soc/intel/cannonlake
 				register "generic.hid" = ""SYNA1202""
 				register "generic.desc" = ""Synaptics Touchpad""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C23_IRQ)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x20"
 				device i2c 2c on end
 			end


### PR DESCRIPTION
Use the new "detect" method instead of "probed". Fixes an uncommon issue where I2C HID fails to initialize the device in Linux.

Test:

- Reboot 50 times, ensure touchpad works on every boot
- Boot to Windows, ensure touchpad works and is detected as an I2C HID device

Tested on:

- [ ] addw1
- [ ] addw2
- [ ] bonw14
- [ ] darp5
- [ ] darp6
- [ ] darp7
- [x] darp8
- [x] galp5
- [x] gaze15
- [x] gaze16
- [ ] gaze17
- [ ] lemp9
- [x] lemp10
- [x] lemp11
- [ ] oryp6
- [ ] oryp7
- [x] oryp8
- [x] oryp9