### PR TITLE
Revert "soc/intel/alderlake: Remove some ACPI device names"

### DIFF
--- a/src/soc/intel/alderlake/chip.c
+++ b/src/soc/intel/alderlake/chip.c
@@ -149,6 +149,9 @@ const char *soc_acpi_name(const struct device *dev)
 	case PCH_DEVFN_HDA:		return "HDAS";
 	case PCH_DEVFN_SMBUS:		return "SBUS";
 	case PCH_DEVFN_GBE:		return "GLAN";
+	case PCH_DEVFN_SRAM:		return "SRAM";
+	case PCH_DEVFN_SPI:		return "FSPI";
+	case PCH_DEVFN_CSE:		return "HEC1";
 #if CONFIG(SOC_INTEL_ALDERLAKE_PCH_N)
 	case PCH_DEVFN_EMMC:		return "EMMC";
 #endif


### PR DESCRIPTION
This reverts commit 884467a2b56c3ecd143055d6b338698d6a2c2a90.

Without these names, Windows fails with `INTERNAL_POWER_ERROR` (0xA0)
bugcheck with paramter 0x680. Linux reports errors for the devices, but
continues to work.

> The runtime power framework could not parse a required ACPI table
> due to it either being missing or malformed. This is usually due
> to a BIOS error.

Must be tested on galp6, which should currently be broken.