### PR TITLE
soc/intel/alderlake: Add IRQ for non-existent CPU PCIe device

### DIFF
--- a/src/soc/intel/alderlake/fsp_params.c
+++ b/src/soc/intel/alderlake/fsp_params.c
@@ -64,6 +64,7 @@ static const struct slot_irq_constraints irq_constraints[] = {
 		.slot = SA_DEV_SLOT_CPU_1,
 		.fns = {
 			FIXED_INT_PIRQ(SA_DEVFN_CPU_PCIE1_0, PCI_INT_A, PIRQ_A),
+			FIXED_INT_PIRQ(SA_DEVFN_CPU_PCIE1_1, PCI_INT_B, PIRQ_B),
 		},
 	},
 	{


### PR DESCRIPTION
Device 0:01.1 does not exist on ADL-P. I assume this works because the
bridged device has function 1.

Fixes the following error in Linux:

    pcieport 0000:00:01.0: can't derive routing for PCI INT B
    snd_hda_intel 0000:01:00.1: PCI INT B: no GSI - using ISA IRQ 10

Which in turn resolves the conflict with the PCH HDA device...again:

    irq 10: nobody cared (try booting with the "irqpoll" option)
    <snip>
    [<00000000bf549647>] azx_interrupt [snd_hda_codec]
    Disabling IRQ #10

### Test

- [x] oryp9
- [x] gaze17-3050
- [x] gaze17-3060-b