### PR TITLE
soc/intel/alderlake: Only use CH0 for mixed-topo

### DIFF
--- a/src/soc/intel/alderlake/meminit.c
+++ b/src/soc/intel/alderlake/meminit.c
@@ -54,8 +54,8 @@ static const struct soc_mem_cfg soc_mem_cfg[] = {
 			 * configuration.
 			 */
 			.half_channel = BIT(0),
-			/* In mixed topologies, either channel 0 or 1 can be memory-down. */
-			.mixed_topo = BIT(0) | BIT(1),
+			/* In mixed topologies, channel 0 is always memory-down. */
+			.mixed_topo = BIT(0),
 		},
 	},
 	[MEM_TYPE_DDR5] = {


### PR DESCRIPTION
Fixes booting lemp11 with no DIMM installed.

This is a problem because Chromebooks only use CH1 for mixed topo.