### PR TITLE
mb/system76: Set SMBIOS wakeup type to power switch

### DIFF
--- a/src/mainboard/system76/addw1/ramstage.c
+++ b/src/mainboard/system76/addw1/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <variant/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/adl-p/ramstage.c
+++ b/src/mainboard/system76/adl-p/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <mainboard/gpio.h>
 #include <soc/ramstage.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {

--- a/src/mainboard/system76/bonw14/ramstage.c
+++ b/src/mainboard/system76/bonw14/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/cml-u/ramstage.c
+++ b/src/mainboard/system76/cml-u/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/gaze15/ramstage.c
+++ b/src/mainboard/system76/gaze15/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <variant/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/gaze16/ramstage.c
+++ b/src/mainboard/system76/gaze16/ramstage.c
@@ -1,8 +1,14 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
+#include <smbios.h>
 #include <soc/ramstage.h>
 #include <variant/gpio.h>
 #include "variant.h"
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {

--- a/src/mainboard/system76/gaze17/ramstage.c
+++ b/src/mainboard/system76/gaze17/ramstage.c
@@ -1,7 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
+#include <smbios.h>
 #include <soc/ramstage.h>
 #include <variant/gpio.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {

--- a/src/mainboard/system76/kbl-u/ramstage.c
+++ b/src/mainboard/system76/kbl-u/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/lemp9/ramstage.c
+++ b/src/mainboard/system76/lemp9/ramstage.c
@@ -1,7 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
+#include <smbios.h>
 #include <soc/ramstage.h>
 #include "gpio.h"
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 void mainboard_silicon_init_params(FSPS_UPD *supd)
 {

--- a/src/mainboard/system76/oryp5/ramstage.c
+++ b/src/mainboard/system76/oryp5/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/oryp6/ramstage.c
+++ b/src/mainboard/system76/oryp6/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <variant/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/oryp8/ramstage.c
+++ b/src/mainboard/system76/oryp8/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <mainboard/gpio.h>
 #include <soc/ramstage.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {

--- a/src/mainboard/system76/tgl-u/ramstage.c
+++ b/src/mainboard/system76/tgl-u/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <mainboard/gpio.h>
 #include <soc/ramstage.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/whl-u/ramstage.c
+++ b/src/mainboard/system76/whl-u/ramstage.c
@@ -2,6 +2,12 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}
 
 static void mainboard_init(void *chip_info)
 {


### PR DESCRIPTION
Set the system wake-up type to power switch.

- SMBIOS requires it not be "Unknown".
- Windows hardware tests require it not be "Reserved".

Before:

```
$ sudo dmidecode -t system | grep Wake
	Wake-up Type: Reserved
```

After:

```
$ sudo dmidecode -t system | grep Wake
	Wake-up Type: Power Switch
```

**Note**: This is incorrect if WoL is used for power-on, as it should then report "LAN Remote".

### Ref

- [SMBIOS Specification 3.6.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf)
  - 6.2 Required structures and data, Table 4
  - 7.2.2 System - Wake-up Type