### PR TITLE
mb/system76: Set gfx register

### DIFF
--- a/src/mainboard/system76/gaze16/devicetree.cb
+++ b/src/mainboard/system76/gaze16/devicetree.cb
@@ -95,6 +95,8 @@ chip soc/intel/tigerlake
 			register "DdiPortBConfig" = "DDI_PORT_CFG_NO_LFP"
 			register "DdiPortBHpd" = "1"
 			register "DdiPortBDdc" = "1"
+
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
 		end
 		device ref dptf on end
 		device ref gna on end

--- a/src/mainboard/system76/lemp9/devicetree.cb
+++ b/src/mainboard/system76/lemp9/devicetree.cb
@@ -61,7 +61,9 @@ chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x1401 inherit
 		device pci 00.0 on  end # Host Bridge
-		device pci 02.0 on  end # Integrated Graphics Device
+		device pci 02.0 on      # Integrated Graphics Device
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
+		end
 		device pci 04.0 on      # SA Thermal device
 			register "Device4Enable" = "1"
 		end

--- a/src/mainboard/system76/oryp8/devicetree.cb
+++ b/src/mainboard/system76/oryp8/devicetree.cb
@@ -104,6 +104,8 @@ chip soc/intel/tigerlake
 			register "DdiPortAConfig" = "DDI_PORT_CFG_EDP"
 			register "DdiPortAHpd" = "1"
 			register "DdiPortADdc" = "0"
+
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
 		end
 		device ref dptf on end
 		device ref peg0 on


### PR DESCRIPTION
Fixes brightness controls on Windows 10.

These were lost during the rebase.

Upstream: https://review.coreboot.org/c/coreboot/+/67636
Fixes: https://github.com/system76/firmware-open/issues/355