### PR TITLE
mb/system76/adl-p: Always send signal for PMC hack

### DIFF
--- a/src/mainboard/system76/adl-p/acpi/sleep.asl
+++ b/src/mainboard/system76/adl-p/acpi/sleep.asl
@@ -37,10 +37,8 @@ Method (MWAK, 1, Serialized)
 Method (MS0X, 1, Serialized)
 {
 	If (Arg0 == 1) {
-#if CONFIG_BOARD_SYSTEM76_LEMP11
 		/* HACK: Inform EC to apply PMC hack for S0ix issue */
 		\_SB.PCI0.LPCB.EC0.PTS (0)
-#endif
 		/* S0ix Entry */
 		PGPM (MISCCFG_GPIO_PM_CONFIG_BITS)
 	} Else {


### PR DESCRIPTION
Other boards may have the S0ix issue. Always send PTS and let the EC choose to apply the hack.