### PR TITLE
tgl-u, adl-p: Remove CPU PCIe RP RTD3 config

### DIFF
--- a/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
@@ -22,12 +22,6 @@ chip soc/intel/alderlake
 				.clk_req = 0,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD2_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_F20)" # M2_CPU_SSD2_RST#
-				register "srcclk_pin" = "0" # SSD2_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref tcss_xhci on
 			register "tcss_ports[0]" = "TCSS_PORT_DEFAULT(OC_SKIP)"

--- a/src/mainboard/system76/adl-p/variants/galp6/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/galp6/overridetree.cb
@@ -20,12 +20,6 @@ chip soc/intel/alderlake
 				.clk_req = 0,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD1_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_F20)" # M2_SSD1_RST#
-				register "srcclk_pin" = "0" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref tcss_xhci on
 			register "tcss_ports[0]" = "TCSS_PORT_DEFAULT(OC_SKIP)"

--- a/src/mainboard/system76/adl-p/variants/lemp11/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/lemp11/overridetree.cb
@@ -20,12 +20,6 @@ chip soc/intel/alderlake
 				.clk_req = 0,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD2_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_F20)" # M2_CPU_SSD2_RST#
-				register "srcclk_pin" = "0" # SSD0_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref tcss_xhci on
 			register "tcss_ports[0]" = "TCSS_PORT_DEFAULT(OC_SKIP)"

--- a/src/mainboard/system76/adl-p/variants/oryp10/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/oryp10/overridetree.cb
@@ -41,13 +41,6 @@ chip soc/intel/alderlake
 				.clk_req = 0,
 				.flags = PCIE_RP_LTR,
 			}"
-			# FIXME: WD drives fail to suspend
-			#chip soc/intel/common/block/pcie/rtd3
-			#	register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # M2_PWR_EN1
-			#	register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-			#	register "srcclk_pin" = "0" # SSD0_CLKREQ#
-			#	device generic 0 on end
-			#end
 		end
 		device ref pcie4_1 on
 			# CPU PCIe RP#3 x4, Clock 4 (SSD2)
@@ -56,13 +49,6 @@ chip soc/intel/alderlake
 				.clk_req = 4,
 				.flags = PCIE_RP_LTR,
 			}"
-			# FIXME: WD drives fail to suspend
-			#chip soc/intel/common/block/pcie/rtd3
-			#	register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C2)" # M2_PWR_EN2
-			#	register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-			#	register "srcclk_pin" = "4" # SSD1_CLKREQ#
-			#	device generic 0 on end
-			#end
 		end
 		device ref tcss_xhci on
 			register "tcss_ports[0]" = "TCSS_PORT_DEFAULT(OC_SKIP)"

--- a/src/mainboard/system76/adl-p/variants/oryp9/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/oryp9/overridetree.cb
@@ -41,13 +41,6 @@ chip soc/intel/alderlake
 				.clk_req = 0,
 				.flags = PCIE_RP_LTR,
 			}"
-			# FIXME: WD drives fail to suspend
-			#chip soc/intel/common/block/pcie/rtd3
-			#	register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # M2_PWR_EN1
-			#	register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-			#	register "srcclk_pin" = "0" # SSD0_CLKREQ#
-			#	device generic 0 on end
-			#end
 		end
 		device ref pcie4_1 on
 			# CPU PCIe RP#3 x4, Clock 4 (SSD2)
@@ -56,13 +49,6 @@ chip soc/intel/alderlake
 				.clk_req = 4,
 				.flags = PCIE_RP_LTR,
 			}"
-			# FIXME: WD drives fail to suspend
-			#chip soc/intel/common/block/pcie/rtd3
-			#	register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C2)" # M2_PWR_EN2
-			#	register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-			#	register "srcclk_pin" = "4" # SSD1_CLKREQ#
-			#	device generic 0 on end
-			#end
 		end
 		device ref tcss_xhci on
 			register "tcss_ports[0]" = "TCSS_PORT_DEFAULT(OC_SKIP)"

--- a/src/mainboard/system76/tgl-u/variants/darp7/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/darp7/overridetree.cb
@@ -21,12 +21,6 @@ chip soc/intel/tigerlake
 			# PCIe PEG0 x4, Clock 0 (SSD1)
 			register "PcieClkSrcUsage[0]" = "0x40"
 			register "PcieClkSrcClkReq[0]" = "0"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_B16)" # SSD1_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_D13)" # GPP_D13_SSD1_PLT_RST#
-				register "srcclk_pin" = "0" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref north_xhci on # J_TYPEC2
 			register "UsbTcPortEn" = "1"

--- a/src/mainboard/system76/tgl-u/variants/galp5/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/galp5/overridetree.cb
@@ -21,12 +21,6 @@ chip soc/intel/tigerlake
 			# PCIe PEG0 x4, Clock 0 (SSD1)
 			register "PcieClkSrcUsage[0]" = "0x40"
 			register "PcieClkSrcClkReq[0]" = "0"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD1_PWR_DN#
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_H0)" # GPP_H0_RTD3
-				register "srcclk_pin" = "0" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref north_xhci on # J_TYPEC2
 			register "UsbTcPortEn" = "1"

--- a/src/mainboard/system76/tgl-u/variants/lemp10/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/lemp10/overridetree.cb
@@ -22,12 +22,6 @@ chip soc/intel/tigerlake
 			# Despite the name, SSD2_CLKREQ# is used for SSD1
 			register "PcieClkSrcUsage[3]" = "0x40"
 			register "PcieClkSrcClkReq[3]" = "3"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C13)" # SSD1_PWR_DN#
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_C22)" # GPP_C12_RTD3 (labeled incorrectly)
-				register "srcclk_pin" = "3" # SSD2_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref north_xhci on # J_TYPEC1
 			register "UsbTcPortEn" = "1"


### PR DESCRIPTION
This has caused nothing but issues trying to get different drives to behave correctly. Just remove it.