### PR TITLE
ADL: Hook up GMA brightness controls

### DIFF
--- a/src/mainboard/system76/adl-p/devicetree.cb
+++ b/src/mainboard/system76/adl-p/devicetree.cb
@@ -32,6 +32,8 @@ chip soc/intel/alderlake
 				[DDI_PORT_A] = DDI_ENABLE_HPD,
 				[DDI_PORT_B] = DDI_ENABLE_HPD | DDI_ENABLE_DDC,
 			}"
+
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
 		end
 		device ref tbt_pcie_rp0 on end
 		device ref shared_sram on end

--- a/src/mainboard/system76/gaze17/variants/3050/overridetree.cb
+++ b/src/mainboard/system76/gaze17/variants/3050/overridetree.cb
@@ -9,6 +9,8 @@ chip soc/intel/alderlake
 				[DDI_PORT_A] = DDI_ENABLE_HPD,
 				[DDI_PORT_B] = DDI_ENABLE_HPD | DDI_ENABLE_DDC,
 			}"
+
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
 		end
 		device ref pcie4_0 on
 			# PCIe PEG0 x4, Clock 0 (SSD2)

--- a/src/mainboard/system76/gaze17/variants/3060/overridetree.cb
+++ b/src/mainboard/system76/gaze17/variants/3060/overridetree.cb
@@ -6,6 +6,8 @@ chip soc/intel/alderlake
 			# DDIA is eDP
 			register "ddi_portA_config" = "1"
 			register "ddi_ports_config[DDI_PORT_A]" = "DDI_ENABLE_HPD"
+
+			register "gfx" = "GMA_DEFAULT_PANEL(0)"
 		end
 		device ref pcie4_0 on
 			# PCIe PEG0 x4, Clock 0 (SSD2)

--- a/src/soc/intel/alderlake/Kconfig
+++ b/src/soc/intel/alderlake/Kconfig
@@ -447,4 +447,16 @@ config BUILDING_WITH_DEBUG_FSP
 	help
 	  Set this option if debug build of FSP is used.
 
+config INTEL_GMA_BCLV_OFFSET
+	default 0xc8258
+
+config INTEL_GMA_BCLV_WIDTH
+	default 32
+
+config INTEL_GMA_BCLM_OFFSET
+	default 0xc8254
+
+config INTEL_GMA_BCLM_WIDTH
+	default 32
+
 endif

--- a/src/soc/intel/alderlake/Makefile.inc
+++ b/src/soc/intel/alderlake/Makefile.inc
@@ -31,6 +31,7 @@ ramstage-y += elog.c
 ramstage-y += espi.c
 ramstage-y += finalize.c
 ramstage-y += fsp_params.c
+ramstage-y += graphics.c
 ramstage-y += hsphy.c
 ramstage-y += lockdown.c
 ramstage-y += me.c

--- a/src/soc/intel/alderlake/chip.h
+++ b/src/soc/intel/alderlake/chip.h
@@ -4,6 +4,7 @@
 #define _SOC_CHIP_H_
 
 #include <drivers/i2c/designware/dw_i2c.h>
+#include <drivers/intel/gma/gma.h>
 #include <device/pci_ids.h>
 #include <intelblocks/cfg.h>
 #include <intelblocks/gpio.h>
@@ -637,6 +638,9 @@ struct soc_intel_alderlake_config {
 	 * Set this to 1 in order to disable Package C-state demotion.
 	 */
 	bool disable_package_c_state_demotion;
+
+	/* i915 struct for GMA backlight control */
+	struct i915_gpu_controller_info gfx;
 };
 
 typedef struct soc_intel_alderlake_config config_t;

--- a/src/soc/intel/alderlake/graphics.c
+++ b/src/soc/intel/alderlake/graphics.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <intelblocks/graphics.h>
+#include <soc/ramstage.h>
+const struct i915_gpu_controller_info *
+intel_igd_get_controller_info(const struct device *const dev)
+{
+	const struct soc_intel_alderlake_config *const chip = dev->chip_info;
+	return &chip->gfx;
+}


### PR DESCRIPTION
- Fixes brightness controls on Windows 10
- Fixes brightness controls on Linux 6.1

Might fix the issue where external displays become the default display.

Upstream: https://review.coreboot.org/c/coreboot/+/69076