### PR TITLE
mb/system76/{adl-p,tgl-u}: Disable SATA DevSlp

### DIFF
--- a/src/mainboard/system76/adl-p/devicetree.cb
+++ b/src/mainboard/system76/adl-p/devicetree.cb
@@ -73,7 +73,8 @@ chip soc/intel/alderlake
 		device ref sata on
 			register "sata_salp_support" = "1"
 			register "sata_ports_enable[1]" = "1" # SSD1
-			register "sata_ports_dev_slp[1]" = "1" # GPP_H12 (SATA1_DEVSLP1)
+			# FIXME: DevSlp breaks S0ix
+			#register "sata_ports_dev_slp[1]" = "1" # GPP_H12 (SATA1_DEVSLP1)
 		end
 		device ref pch_espi on
 			register "gen1_dec" = "0x00040069" # EC PM channel

--- a/src/mainboard/system76/adl-p/variants/galp6/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/galp6/overridetree.cb
@@ -129,6 +129,7 @@ chip soc/intel/alderlake
 				device i2c 38 on end
 			end
 		end
+		device ref sata off end
 		device ref pcie_rp5 on
 			# PCIe RP#5 x1, Clock 2 (WLAN)
 			register "pch_pcie_rp[PCH_RP(5)]" = "{

--- a/src/mainboard/system76/tgl-u/variants/darp7/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/darp7/overridetree.cb
@@ -124,7 +124,8 @@ chip soc/intel/tigerlake
 		device ref sata on
 			# SATA1 (SSD0)
 			register "SataPortsEnable[1]" = "1"
-			register "SataPortsDevSlp[1]" = "1"
+			# FIXME: DevSlp breaks S0ix
+			#register "SataPortsDevSlp[1]" = "1"
 			register "SataPortsEnableDitoConfig[1]" = "1"
 			register "SataSalpSupport" = "1"
 		end

--- a/src/mainboard/system76/tgl-u/variants/lemp10/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/lemp10/overridetree.cb
@@ -104,7 +104,8 @@ chip soc/intel/tigerlake
 		device ref sata on
 			# SATA1 (SSD2)
 			register "SataPortsEnable[1]" = "1"
-			register "SataPortsDevSlp[1]" = "1"
+			# FIXME: DevSlp breaks S0ix
+			#register "SataPortsDevSlp[1]" = "1"
 			register "SataPortsEnableDitoConfig[1]" = "1"
 			register "SataSalpSupport" = "1"
 		end


### PR DESCRIPTION
After changing EC detection of S0ix from `CPU_C10_GATE#` to `SLP_S0#`, DevSlp blocks suspend entry. Disable it for now.

Must be tested on:

- lemp10
- lemp11
- darp7
- darp8

galp5, galp6, oryp9, and oryp10 do not support SATA.