### PR TITLE
soc/intel/adl/acpi: add FSPI to DSDT

### DIFF
--- a/src/soc/intel/alderlake/acpi/serialio.asl
+++ b/src/soc/intel/alderlake/acpi/serialio.asl
@@ -50,6 +50,12 @@ Device (I2C7)
 	Name (_DDN, "Serial IO I2C Controller 7")
 }
 
+Device (FSPI)
+{
+	Name (_ADR, 0x001f0005)
+	Name (_DDN, "Fast SPI")
+}
+
 Device (SPI0)
 {
 	Name (_ADR, 0x001e0002)


### PR DESCRIPTION
A previous CL ("Add missing ACPI device path names", commit d22500f0c61f8c8e10d8f4a24e3e2bf031163c07) caused some errors from the Kernel on Brya devices (see Tim's comment on patchset 8):

> ACPI Error: AE_NOT_FOUND, While resolving a named reference package element - \_SB_.PCI0.FSPI

FSPI is defined in `src/soc/intel/alderlake/chipset.cb`: `device pci 1f.5 alias fast_spi on end`

This CL adds the corresponding FSPI device to the DSDT to prevent the error mentioned above.

Reviewed-on: https://review.coreboot.org/c/coreboot/+/69920