### PR TITLE
galp5: Re-add CPU PCIe RTD3

### DIFF
--- a/src/mainboard/system76/tgl-u/variants/galp5/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/galp5/overridetree.cb
@@ -21,6 +21,12 @@ chip soc/intel/tigerlake
 			# PCIe PEG0 x4, Clock 0 (SSD1)
 			register "PcieClkSrcUsage[0]" = "0x40"
 			register "PcieClkSrcClkReq[0]" = "0"
+			chip soc/intel/common/block/pcie/rtd3
+				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD1_PWR_DN#
+				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_H0)" # GPP_H0_RTD3
+				register "srcclk_pin" = "0" # SSD1_CLKREQ#
+				device generic 0 on end
+			end
 		end
 		device ref north_xhci on # J_TYPEC2
 			register "UsbTcPortEn" = "1"


### PR DESCRIPTION
Tested with the following drives:

- Crucial P5 Plus (CT500P5PSSD8)
- Kingston KC3000 (SKC3000S/512G)
- Sabrent Rocket NVMe 4.0 (SB-ROCKET-NVMEe4-500)
- Samsung 970 EVO (MZ-V7E250)
- Samsung 970 EVO Plus (MZ-V7S250)
- Samsung 980 PRO (MZ-V8P2T0)
- WD Black SN850X (WDS100T2XD0E)
- WD Blue SN580 (WDS500G2B0C)
- WD Green SN350 (WDS240G2G0C)

Test:

- PCH asserts `SLP_S0#` during suspend (power LED blinks)
- `slp_s0_residency_usec` increases after suspend