### PR TITLE
darp8: Add CPU PCIe RTD3 and AER

### DIFF
--- a/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
@@ -20,7 +20,7 @@ chip soc/intel/alderlake
 			register "cpu_pcie_rp[CPU_RP(1)]" = "{
 				.clk_src = 0,
 				.clk_req = 0,
-				.flags = PCIE_RP_LTR,
+				.flags = PCIE_RP_LTR | PCIE_RP_AER,
 			}"
 			chip soc/intel/common/block/pcie/rtd3
 				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD2_PWR_EN

--- a/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl-p/variants/darp8/overridetree.cb
@@ -22,6 +22,12 @@ chip soc/intel/alderlake
 				.clk_req = 0,
 				.flags = PCIE_RP_LTR,
 			}"
+			chip soc/intel/common/block/pcie/rtd3
+				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # SSD2_PWR_EN
+				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_F20)" # M2_CPU_SSD2_RST#
+				register "srcclk_pin" = "0" # SSD2_CLKREQ#
+				device generic 0 on end
+			end
 		end
 		device ref tcss_xhci on
 			register "tcss_ports[0]" = "TCSS_PORT_DEFAULT(OC_SKIP)"


### PR DESCRIPTION
Tested with the following drives:

- Crucial P5 Plus (CT500P5PSSD8)
- Kingston KC3000 (SKC3000S/512G)
- Sabrent Rocket NVMe 4.0 (SB-ROCKET-NVMEe4-500)
- Samsung 970 EVO (MZ-V7E250)
- Samsung 970 EVO Plus (MZ-V7S250)
- Samsung 980 PRO (MZ-V8P2T0)
- WD Black SN850X (WDS100T2XD0E)
- WD Blue SN580 (WDS500G2B0C)
- WD Green SN350 (WDS240G2G0C)

Test:

- PCH asserts `SLP_S0#` during suspend (power LED blinks)
- `slp_s0_residency_usec` increases after suspend