### PR TITLE
gaze17: Remove RTD3 configs

### DIFF
--- a/src/mainboard/system76/adl/variants/gaze17-3050/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/gaze17-3050/overridetree.cb
@@ -103,14 +103,6 @@ chip soc/intel/alderlake
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				# XXX: Enable tied to 3.3VS?
-				#register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D14)" # M2_PWR_EN1
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-				register "disable_l23" = "true"
-				register "srcclk_pin" = "1" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref pcie_rp9 on
 			# PCIe RP#9 x1, Clock 6 (GLAN)
@@ -119,13 +111,6 @@ chip soc/intel/alderlake
 				.clk_req = 6,
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				# XXX: Enable tied to VDD3?
-				#register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D4)" # GPIO_LAN_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-				register "srcclk_pin" = "6" # GLAN_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref pcie_rp10 on
 			# PCIe RP#10 x1, Clock 2 (WLAN)
@@ -134,12 +119,6 @@ chip soc/intel/alderlake
 				.clk_req = 2,
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_E3)" # PCH_WLAN_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-				register "srcclk_pin" = "2" # WLAN_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref pcie_rp11 on
 			# PCIe RP#11 x1, Clock 5 (CARD)
@@ -148,13 +127,6 @@ chip soc/intel/alderlake
 				.clk_req = 5,
 				.flags = PCIE_RP_HOTPLUG | PCIE_RP_LTR | PCIE_RP_AER,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				# XXX: Enable tied to 3.3VS?
-				#register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_B7)" # CARD_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-				register "srcclk_pin" = "5" # CARD_CLKREQ#
-				device generic 0 on end
-			end
 		end
 	end
 end

--- a/src/mainboard/system76/adl/variants/gaze17-3060-b/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/gaze17-3060-b/overridetree.cb
@@ -109,12 +109,6 @@ chip soc/intel/alderlake
 				.clk_req = 2,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_E3)" # PCH_WLAN_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-				register "srcclk_pin" = "2" # WLAN_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref pcie_rp6 on
 			# PCIe root port #6 x1, Clock 5 (CARD)
@@ -123,12 +117,6 @@ chip soc/intel/alderlake
 				.clk_req = 5,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				# XXX: No enable_gpio = no D3cold?
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-				register "srcclk_pin" = "5" # CARD_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref pcie_rp7 on
 			# PCIe root port #7 x1, Clock 6 (GLAN)
@@ -147,14 +135,6 @@ chip soc/intel/alderlake
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				# XXX: Enable tied to 3.3VS?
-				#register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C2)" # SATA_M2_PWR_EN1
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B13)" # BUF_PLT_RST#
-				register "disable_l23" = "true" # Fixes suspend on WD drives
-				register "srcclk_pin" = "1" # SSD_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref gbe on end
 	end


### PR DESCRIPTION
According to the schematics, the components/pins for RTD3 support are not connected. The enable GPIO for components is tied directly to power and the reset GPIO is tied to `BUF_PLT_RST#`.