### PR TITLE
SMBIOS Wake-up Type

### DIFF
--- a/src/ec/system76/ec/Makefile.inc
+++ b/src/ec/system76/ec/Makefile.inc
@@ -2,6 +2,9 @@
 ifeq ($(CONFIG_EC_SYSTEM76_EC),y)
 
 all-y += system76_ec.c
+
+ramstage-y += smbios.c
+
 smm-$(CONFIG_DEBUG_SMI) += system76_ec.c
 
 endif

--- a/src/ec/system76/ec/smbios.c
+++ b/src/ec/system76/ec/smbios.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <smbios.h>
+
+smbios_wakeup_type smbios_system_wakeup_type(void)
+{
+	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
+}

--- a/src/mainboard/system76/addw1/ramstage.c
+++ b/src/mainboard/system76/addw1/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <device/device.h>
 #include <variant/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/adl-p/ramstage.c
+++ b/src/mainboard/system76/adl-p/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <mainboard/gpio.h>
 #include <soc/ramstage.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {

--- a/src/mainboard/system76/bonw14/ramstage.c
+++ b/src/mainboard/system76/bonw14/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/cml-u/ramstage.c
+++ b/src/mainboard/system76/cml-u/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/gaze15/ramstage.c
+++ b/src/mainboard/system76/gaze15/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <device/device.h>
 #include <variant/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/gaze17/ramstage.c
+++ b/src/mainboard/system76/gaze17/ramstage.c
@@ -1,13 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <smbios.h>
 #include <soc/ramstage.h>
 #include <variant/gpio.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {

--- a/src/mainboard/system76/oryp5/ramstage.c
+++ b/src/mainboard/system76/oryp5/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/oryp6/ramstage.c
+++ b/src/mainboard/system76/oryp6/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <device/device.h>
 #include <variant/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/tgl-h/ramstage.c
+++ b/src/mainboard/system76/tgl-h/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <soc/ramstage.h>
 #include <variant/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/tgl-u/ramstage.c
+++ b/src/mainboard/system76/tgl-u/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <mainboard/gpio.h>
 #include <soc/ramstage.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {

--- a/src/mainboard/system76/whl-u/ramstage.c
+++ b/src/mainboard/system76/whl-u/ramstage.c
@@ -2,12 +2,6 @@
 
 #include <device/device.h>
 #include <mainboard/gpio.h>
-#include <smbios.h>
-
-smbios_wakeup_type smbios_system_wakeup_type(void)
-{
-	return SMBIOS_WAKEUP_TYPE_POWER_SWITCH;
-}
 
 static void mainboard_init(void *chip_info)
 {


### PR DESCRIPTION
Move the implementation of `smbios_system_wakeup_type` from the mainboards to the EC for all models that use System76 EC (everything except KBL).

Requires: https://github.com/system76/ec/pull/326
Upstream: https://review.coreboot.org/c/coreboot/+/71802