### PR TITLE
ec/system76/ec: Do not call reset on wake

### DIFF
--- a/src/ec/system76/ec/acpi/ec.asl
+++ b/src/ec/system76/ec/acpi/ec.asl
@@ -90,9 +90,6 @@ Device (\_SB.PCI0.LPCB.EC0)
 			// Notify of changes
 			Notify(^^^^AC, 0)
 			Notify(^^^^BAT0, 0)
-
-			// Reset System76 Device
-			^^^^S76D.RSET()
 		}
 	}
 


### PR DESCRIPTION
Resetting the device will cause the keyboard backlight and airplane LED to lose their state.