### PR TITLE
mb/system76/adl: darp8: Reduce power limits

### DIFF
--- a/src/mainboard/system76/adl/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/darp8/overridetree.cb
@@ -3,8 +3,8 @@ chip soc/intel/alderlake
 	# battery power. This seems to only happen with the i7 units.
 	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
 		.tdp_pl1_override = 20,
-		.tdp_pl2_override = 56,
-		.tdp_pl4 = 56, // FIXME: Set to 65
+		.tdp_pl2_override = 42,
+		.tdp_pl4 = 42, // FIXME: Set to 56
 	}"
 
 	# GPE configuration


### PR DESCRIPTION
For some reason, the i7 darp8 cannot handle a PL4 value of 56W. Values as low as 45W will cause it to power off under load when on battery power. Reduce it to 42W (1.5x TDP) to prevent this from happening.

TEST=Boot on battery power and build firmware-open and linux.