### PR TITLE
galp7: Further reduce power limits

### DIFF
--- a/src/mainboard/system76/rpl/variants/galp7/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/galp7/overridetree.cb
@@ -1,9 +1,12 @@
 chip soc/intel/alderlake
 	register "power_limits_config[RPL_P_682_642_482_45W_CORE]" = "{
-		.tdp_pl1_override = 45,
-		.tdp_pl2_override = 78,
-		.tdp_pl4 = 90,
+		.tdp_pl1_override = 40,
+		.tdp_pl2_override = 68,
+		.tdp_psyspl2 = 78,
+		.tdp_pl4 = 88,
 	}"
+
+	register "platform_pmax" = "88"
 
 	device domain 0 on
 		subsystemid 0x1558 0x4041 inherit


### PR DESCRIPTION
Further reduce power limits to prevent power off on the i7 unit. Also set PsysPL2 and PsysPmax for good measure, even though they seem to have no effect.
