### PR TITLE
mb/system76: Remove PL4 values

### DIFF
--- a/src/mainboard/system76/adl/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/darp8/overridetree.cb
@@ -1,10 +1,7 @@
 chip soc/intel/alderlake
-	# HACK: Limit PL4 to PL2 to prevent power-off when system is booted on
-	# battery power. This seems to only happen with the i7 units.
 	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
 		.tdp_pl1_override = 20,
 		.tdp_pl2_override = 56,
-		.tdp_pl4 = 56, // FIXME: Set to 65
 	}"
 
 	# GPE configuration

--- a/src/mainboard/system76/adl/variants/galp6/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/galp6/overridetree.cb
@@ -2,7 +2,6 @@ chip soc/intel/alderlake
 	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
 		.tdp_pl1_override = 28,
 		.tdp_pl2_override = 60,
-		.tdp_pl4 = 90,
 	}"
 
 	# GPE configuration

--- a/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
@@ -2,7 +2,6 @@ chip soc/intel/alderlake
 	register "power_limits_config[ADL_P_142_242_282_15W_CORE]" = "{
 		.tdp_pl1_override = 15,
 		.tdp_pl2_override = 46,
-		.tdp_pl4 = 65,
 	}"
 
 	# GPE configuration

--- a/src/mainboard/system76/adl/variants/oryp10/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/oryp10/overridetree.cb
@@ -1,10 +1,8 @@
 chip soc/intel/alderlake
-	# HACK: Limit PL4 to prevent power off on battery power.
 	register "power_limits_config[ADL_P_642_682_45W_CORE]" = "{
 		.tdp_pl1_override = 45,
 		.tdp_pl2_override = 115,
 		.tdp_psyspl2 = 135,
-		.tdp_pl4 = 72,
 	}"
 
 	# Thermal

--- a/src/mainboard/system76/adl/variants/oryp9/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/oryp9/overridetree.cb
@@ -1,10 +1,8 @@
 chip soc/intel/alderlake
-	# HACK: Limit PL4 to prevent power off on battery power.
 	register "power_limits_config[ADL_P_642_682_45W_CORE]" = "{
 		.tdp_pl1_override = 45,
 		.tdp_pl2_override = 115,
 		.tdp_psyspl2 = 135,
-		.tdp_pl4 = 72,
 	}"
 
 	# Thermal

--- a/src/mainboard/system76/rpl/variants/galp7/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/galp7/overridetree.cb
@@ -2,7 +2,6 @@ chip soc/intel/alderlake
 	register "power_limits_config[RPL_P_682_642_482_45W_CORE]" = "{
 		.tdp_pl1_override = 45,
 		.tdp_pl2_override = 78,
-		.tdp_pl4 = 90,
 	}"
 
 	device domain 0 on

--- a/src/mainboard/system76/rpl/variants/lemp12/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/lemp12/overridetree.cb
@@ -2,7 +2,6 @@ chip soc/intel/alderlake
 	register "power_limits_config[RPL_P_282_242_142_15W_CORE]" = "{
 		.tdp_pl1_override = 15,
 		.tdp_pl2_override = 46,
-		.tdp_pl4 = 65,
 	}"
 
 	device domain 0 on


### PR DESCRIPTION
System76 EC sets PL4 values through PECI based on AC state. Remove the static PL4 values from coreboot since they won't be used. This will result in sysfs reporting the package default for PL4.

Requires: https://github.com/system76/ec/pull/353