### PR TITLE
mb/system76/adl: Disable DevSlp

### DIFF
--- a/src/mainboard/system76/adl/devicetree.cb
+++ b/src/mainboard/system76/adl/devicetree.cb
@@ -71,7 +71,6 @@ chip soc/intel/alderlake
 		device ref sata on
 			register "sata_salp_support" = "1"
 			register "sata_ports_enable[1]" = "1"
-			register "sata_ports_dev_slp[1]" = "1"
 		end
 		device ref pch_espi on
 			register "gen1_dec" = "0x00040069" # EC PM channel


### PR DESCRIPTION
This got enabled when gaze17 was converted to a variant, but it still breaks drives across suspend.

Fixes using drives on lemp11, darp8 in the PCIe Gen3 slot.