### PR TITLE
mb/system76/adl: darp8,lemp11: Disable RTD3 on SATA port

### DIFF
--- a/src/mainboard/system76/adl/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/darp8/overridetree.cb
@@ -151,12 +151,6 @@ chip soc/intel/alderlake
 				.clk_req = 4,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D16)" # SSD1_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B16)" # M2_SSD1_RST#
-				register "srcclk_pin" = "4" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref pmc hidden
 			chip drivers/intel/pmc_mux

--- a/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
@@ -137,12 +137,6 @@ chip soc/intel/alderlake
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR,
 			}"
-			chip soc/intel/common/block/pcie/rtd3
-				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D16)" # SSD1_PWR_EN
-				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_H0)" # M2_SSD1_RST#
-				register "srcclk_pin" = "1" # SSD1_CLKREQ#
-				device generic 0 on end
-			end
 		end
 		device ref pmc hidden
 			chip drivers/intel/pmc_mux


### PR DESCRIPTION
After switching to S3, the use of RTD3 on the SATA port breaks drives exiting D3cold.

Fixes drives being unusable after suspend.

Tested on darp8 with a 970 EVO SSD and Crucial P5 in J_SSD1.