### PR TITLE
soc/intel/adl: Fix LPM substates for RPL-HX

### DIFF
--- a/src/soc/intel/alderlake/cpu.c
+++ b/src/soc/intel/alderlake/cpu.c
@@ -301,10 +301,10 @@ uint8_t get_supported_lpm_mask(void)
 	case ADL_M: /* fallthrough */
 	case ADL_N:
 	case ADL_P:
-	case RPL_HX:
 	case RPL_P:
 		return LPM_S0i2_0 | LPM_S0i3_0;
 	case ADL_S:
+	case RPL_HX:
 		return LPM_S0i2_0 | LPM_S0i2_1;
 	default:
 		printk(BIOS_ERR, "Unknown ADL CPU type: %d\n", type);


### PR DESCRIPTION
Ref: Default values of `PmcLpmS0ixSubStateEnableMask` in FSP.