### PR TITLE
[WIP] drivers/pc80/tpm: Fix tis_readresponse()

### DIFF
--- a/src/drivers/pc80/tpm/tis.c
+++ b/src/drivers/pc80/tpm/tis.c
@@ -284,6 +284,14 @@ static inline int tis_wait_valid_data(int locality)
 static inline int tis_has_valid_data(int locality)
 {
 	const u8 has_data = TIS_STS_DATA_AVAILABLE | TIS_STS_VALID;
+
+	/*
+	 * Certain TPMs require a small delay here, as they have set
+	 * TIS_STS_VALID first and TIS_STS_DATA_AVAILABLE few clocks later.
+	 */
+	if ((tpm_read_status(locality) & has_data) == has_data)
+		return 1;
+
 	return (tpm_read_status(locality) & has_data) == has_data;
 }
 
@@ -581,14 +589,6 @@ static u32 tis_readresponse(u8 *buffer, size_t *len)
 
 		if (offset == expected_count)
 			break;	/* We got all we need */
-
-		/*
-		 * Certain TPMs seem to need some delay between tis_wait_valid()
-		 * and tis_has_valid_data(), or some race-condition-related
-		 * issue will occur.
-		 */
-		if (CONFIG(TPM_RDRESP_NEED_DELAY))
-			udelay(10);
 
 	} while (tis_has_valid_data(locality));
 


### PR DESCRIPTION
For testing [CB:76315](https://review.coreboot.org/c/coreboot/+/76315)

---

`TPM_RDRESP_NEED_DELAY` was introduced in 2018 in [CB:25322](https://review.coreboot.org/c/coreboot/+/25322) after observing errors with SLB9635 by Infineon. It has been confirmed also SLB9670 and SLB9672 require a fix or delay here.

Presumambly, prior to [CB:4388](https://review.coreboot.org/c/coreboot/+/4388) SLB9635 did not have this problem, as this particular TPM shipped with samsung/lumpy Chromebook since 2011. In [CB:4388](https://review.coreboot.org/c/coreboot/+/4388) the code changed from polling the status register (+burst_count) using a 32bit read to separated 8bit reads.

So far, experiments on samsung/lumpy and SLB9635 indicate that it would be sufficient to add a single tpm_read_status() call to see `TIS_STS_DATA_AVAILABLE` as set at the time of evaluating the loop exit condition.