### PR TITLE
soc/intel/cannonlake: Hook up ucode for CML-S

### DIFF
--- a/src/soc/intel/cannonlake/Makefile.inc
+++ b/src/soc/intel/cannonlake/Makefile.inc
@@ -104,6 +104,8 @@ cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-8e-0c
 else ifeq ($(CONFIG_SOC_INTEL_COMETLAKE),y)
 ifeq ($(CONFIG_SOC_INTEL_CANNONLAKE_PCH_H),y)
 cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-a5-02
+cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-a5-03
+cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-a5-05
 else
 cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-8e-0c
 cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-a6-00


### PR DESCRIPTION
Hook up microcode from 3rdparty repo for:

- 06-a5-03 (CPUID signature: 0xa0653)
- 06-a5-05 (CPUID signature: 0xa0655)

Fixes loading microcode on system76/bonw14.

upstream: [CB:76415](https://review.coreboot.org/c/coreboot/+/76415)