### PR TITLE
soc/intel/alderlake: Move RPL-HX power limits to correct file

### DIFF
--- a/src/soc/intel/alderlake/chipset.cb
+++ b/src/soc/intel/alderlake/chipset.cb
@@ -90,36 +90,6 @@ chip soc/intel/alderlake
 		.tdp_pl4 = 114,
 	}"
 
-	register "power_limits_config[RPL_HX_8_16_55W_CORE]" = "{
-		.tdp_pl1_override = 55,
-		.tdp_pl2_override = 130,
-		.tdp_pl4 = 200,
-	}"
-
-	register "power_limits_config[RPL_HX_8_12_55W_CORE]" = "{
-		.tdp_pl1_override = 55,
-		.tdp_pl2_override = 130,
-		.tdp_pl4 = 200,
-	}"
-
-	register "power_limits_config[RPL_HX_8_8_55W_CORE]" = "{
-		.tdp_pl1_override = 55,
-		.tdp_pl2_override = 130,
-		.tdp_pl4 = 200,
-	}"
-
-	register "power_limits_config[RPL_HX_6_8_55W_CORE]" = "{
-		.tdp_pl1_override = 55,
-		.tdp_pl2_override = 130,
-		.tdp_pl4 = 200,
-	}"
-
-	register "power_limits_config[RPL_HX_6_4_55W_CORE]" = "{
-		.tdp_pl1_override = 55,
-		.tdp_pl2_override = 130,
-		.tdp_pl4 = 200,
-	}"
-
 	# NOTE: if any variant wants to override this value, use the same format
 	# as register "common_soc_config.pch_thermal_trip" = "value", instead of
 	# putting it under register "common_soc_config" in overridetree.cb file.

--- a/src/soc/intel/alderlake/chipset_pch_s.cb
+++ b/src/soc/intel/alderlake/chipset_pch_s.cb
@@ -92,6 +92,36 @@ chip soc/intel/alderlake
 		.tdp_pl4 = 44,
 	}"
 
+	register "power_limits_config[RPL_HX_8_16_55W_CORE]" = "{
+		.tdp_pl1_override = 55,
+		.tdp_pl2_override = 130,
+		.tdp_pl4 = 200,
+	}"
+
+	register "power_limits_config[RPL_HX_8_12_55W_CORE]" = "{
+		.tdp_pl1_override = 55,
+		.tdp_pl2_override = 130,
+		.tdp_pl4 = 200,
+	}"
+
+	register "power_limits_config[RPL_HX_8_8_55W_CORE]" = "{
+		.tdp_pl1_override = 55,
+		.tdp_pl2_override = 130,
+		.tdp_pl4 = 200,
+	}"
+
+	register "power_limits_config[RPL_HX_6_8_55W_CORE]" = "{
+		.tdp_pl1_override = 55,
+		.tdp_pl2_override = 130,
+		.tdp_pl4 = 200,
+	}"
+
+	register "power_limits_config[RPL_HX_6_4_55W_CORE]" = "{
+		.tdp_pl1_override = 55,
+		.tdp_pl2_override = 130,
+		.tdp_pl4 = 200,
+	}"
+
 	# NOTE: if any variant wants to override this value, use the same format
 	# as register "common_soc_config.pch_thermal_trip" = "value", instead of
 	# putting it under register "common_soc_config" in overridetree.cb file.


### PR DESCRIPTION
`chipset.cb` is not used when PCH-S is selected, as is the case for RPL-HX. Fix setting power limits by putting the definitions in the correct file.