### PR TITLE
mb/system76: Enable C10 reporting on systems using eSPI

### DIFF
--- a/src/mainboard/system76/adl/ramstage.c
+++ b/src/mainboard/system76/adl/ramstage.c
@@ -23,6 +23,9 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 	params->SataPortDevSlpPinMux[1] = 0x5967400d; // GPP_H13
 
 	params->SataPortsSolidStateDrive[1] = 1;
+
+	// Enable reporting CPU C10 state over eSPI
+	params->PchEspiHostC10ReportEnable = 1;
 }
 
 static void mainboard_init(void *chip_info)

--- a/src/mainboard/system76/tgl-h/variants/gaze16-3050/ramstage.c
+++ b/src/mainboard/system76/tgl-h/variants/gaze16-3050/ramstage.c
@@ -18,4 +18,7 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 
 	// Remap PEG2 as PEG1
 	params->CpuPcieRpFunctionSwap = 1;
+
+	// Enable reporting CPU C10 state over ESPI
+	params->PchEspiHostC10ReportEnable = 1;
 }

--- a/src/mainboard/system76/tgl-h/variants/gaze16-3060/ramstage.c
+++ b/src/mainboard/system76/tgl-h/variants/gaze16-3060/ramstage.c
@@ -15,4 +15,7 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 	params->CpuPcieRpAdvancedErrorReporting[1] = 0;
 	params->CpuPcieRpLtrEnable[1] = 1;
 	params->CpuPcieRpPtmEnabled[1] = 0;
+
+	// Enable reporting CPU C10 state over ESPI
+	params->PchEspiHostC10ReportEnable = 1;
 }

--- a/src/mainboard/system76/tgl-h/variants/oryp8/ramstage.c
+++ b/src/mainboard/system76/tgl-h/variants/oryp8/ramstage.c
@@ -21,4 +21,7 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 
 	// Low latency legacy I/O
 	params->PchLegacyIoLowLatency = 1;
+
+	// Enable reporting CPU C10 state over ESPI
+	params->PchEspiHostC10ReportEnable = 1;
 }


### PR DESCRIPTION
Report CPU C10 state over eSPI so that the EC can use Virtual Wires to detect if PECI can be used.

Ref: https://github.com/system76/ec/pull/393