### PR TITLE
mb/system76/cml-u: Fix inclusion of romstage.c

### DIFF
--- a/src/mainboard/system76/cml-u/Makefile.inc
+++ b/src/mainboard/system76/cml-u/Makefile.inc
@@ -3,6 +3,8 @@ CPPFLAGS_common += -I$(src)/mainboard/$(MAINBOARDDIR)/include
 bootblock-y += bootblock.c
 bootblock-y += gpio_early.c
 
+romstage-y += variants/$(VARIANT_DIR)/romstage.c
+
 ramstage-y += ramstage.c
 ramstage-y += variants/$(VARIANT_DIR)/gpio.c
 ramstage-y += variants/$(VARIANT_DIR)/hda_verb.c


### PR DESCRIPTION
When lemp9 was converted to a variant in CB:64528, the Makefile was not updated to handle the variant-specific `romstage.c`. This, as would be expected, caused memory init errors and broke boot on CML-U boards.

Tested lemp9 boots to payload again.

Fixes: 5b7b04c938f2 ("mb/system76/cml-u: Convert lemp9 to a variant")
Fixes: https://github.com/system76/firmware-open/issues/393
Upstream: [CB:76871](https://review.coreboot.org/c/coreboot/+/76871)