### PR TITLE
mb/system76/rpl: darp9: Add SSD RTD3 configs

### DIFF
--- a/src/mainboard/system76/rpl/variants/darp9/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/darp9/overridetree.cb
@@ -16,6 +16,11 @@ chip soc/intel/alderlake
 				.clk_req = 0,
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
 			}"
+			chip soc/intel/common/block/pcie/rtd3
+				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_F20)" # M2_SSD2_RST#
+				register "srcclk_pin" = "0" # SSD2_CLKREQ#
+				device generic 0 on end
+			end
 		end
 		device ref pcie4_1 on
 			# CPU RP#3 x4, Clock 4 (SSD1)
@@ -24,6 +29,11 @@ chip soc/intel/alderlake
 				.clk_req = 4,
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
 			}"
+			chip soc/intel/common/block/pcie/rtd3
+				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_B16)" # M2_SSD1_RST#
+				register "srcclk_pin" = "4" # SSD1_CLKREQ#
+				device generic 0 on end
+			end
 		end
 		device ref tbt_pcie_rp0 on end
 		device ref tcss_xhci on


### PR DESCRIPTION
Some drives block the CPU from reaching C10 on suspend without the RTD3 config.

Fixes suspend with the following drives:

- Kingston KC3000 (SKC3000D/4096G)
- Kingston HyperX (SHPM2280P2H/240G)
- Solidigm P44 Pro (SSDPFKKW010X7)

The following drives continue to work:

- Samsung 970 Evo (MZVLB250HAHQ)
- WD Black SN770 (WDS250G3X0E)
- WD Green SN350 (WDS240G2G0C-00AJM0)
- WD Blue SN570 (WDS100T3B0C)