### PR TITLE
the i9-13900HX supports up to 128GB 5600 MT/s DDR5 memory

### DIFF
--- a/src/mainboard/system76/rpl/variants/addw3/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/addw3/overridetree.cb
@@ -1,6 +1,6 @@
 chip soc/intel/alderlake
-	# Support 5200 MT/s memory
-	register "max_dram_speed_mts" = "5200"
+	# Support 5600 MT/s memory
+	register "max_dram_speed_mts" = "5600"
 
 	device domain 0 on
 		subsystemid 0x1558 0xa671 inherit

--- a/src/mainboard/system76/rpl/variants/bonw15/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/bonw15/overridetree.cb
@@ -1,6 +1,6 @@
 chip soc/intel/alderlake
-	# Support 5200 MT/s memory
-	register "max_dram_speed_mts" = "5200"
+	# Support 5600 MT/s memory
+	register "max_dram_speed_mts" = "5600"
 
 	device domain 0 on
 		subsystemid 0x1558 0x3702 inherit

--- a/src/mainboard/system76/rpl/variants/serw13/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/serw13/overridetree.cb
@@ -1,6 +1,6 @@
 chip soc/intel/alderlake
-	# Support 5200 MT/s memory
-	register "max_dram_speed_mts" = "5200"
+	# Support 5600 MT/s memory
+	register "max_dram_speed_mts" = "5600"
 
 	device domain 0 on
 		subsystemid 0x1558 0xd502 inherit


### PR DESCRIPTION
See

https://ark.intel.com/content/www/us/en/ark/products/232171/intel-core-i913900hx-processor-36m-cache-up-to-5-40-ghz.html