### PR TITLE
mb/system76: Enable S0ix for darp8/darp9

### DIFF
--- a/src/mainboard/system76/adl/Kconfig
+++ b/src/mainboard/system76/adl/Kconfig
@@ -108,6 +108,10 @@ config MAINBOARD_VERSION
 	default "oryp9" if BOARD_SYSTEM76_ORYP9
 	default "oryp10" if BOARD_SYSTEM76_ORYP10
 
+config CMOS_DEFAULT_FILE
+	default "src/mainboard/\$(MAINBOARDDIR)/cmos-csme.default" if BOARD_SYSTEM76_DARP8
+	default "src/mainboard/\$(MAINBOARDDIR)/cmos.default"
+
 config CONSOLE_POST
 	default y
 

--- a/src/mainboard/system76/adl/cmos-csme.default
+++ b/src/mainboard/system76/adl/cmos-csme.default
@@ -1,0 +1,3 @@
+boot_option=Fallback
+debug_level=Debug
+me_state=Enable

--- a/src/mainboard/system76/adl/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/darp8/overridetree.cb
@@ -1,4 +1,6 @@
 chip soc/intel/alderlake
+	register "s0ix_enable" = "1"
+
 	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
 		.tdp_pl1_override = 20,
 		.tdp_pl2_override = 56,

--- a/src/mainboard/system76/rpl/Kconfig
+++ b/src/mainboard/system76/rpl/Kconfig
@@ -133,6 +133,10 @@ config MAINBOARD_VERSION
 	default "oryp11" if BOARD_SYSTEM76_ORYP11
 	default "serw13" if BOARD_SYSTEM76_SERW13
 
+config CMOS_DEFAULT_FILE
+	default "src/mainboard/\$(MAINBOARDDIR)/cmos-csme.default" if BOARD_SYSTEM76_DARP9
+	default "src/mainboard/\$(MAINBOARDDIR)/cmos.default"
+
 config CONSOLE_POST
 	default y
 

--- a/src/mainboard/system76/rpl/cmos-csme.default
+++ b/src/mainboard/system76/rpl/cmos-csme.default
@@ -1,0 +1,3 @@
+boot_option=Fallback
+debug_level=Debug
+me_state=Enable

--- a/src/mainboard/system76/rpl/variants/darp9/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/darp9/overridetree.cb
@@ -1,4 +1,6 @@
 chip soc/intel/alderlake
+	register "s0ix_enable" = "1"
+
 	register "power_limits_config[RPL_P_682_482_282_28W_CORE]" = "{
 		.tdp_pl1_override = 20,
 		.tdp_pl2_override = 56,


### PR DESCRIPTION
The newer batch of these boards do not de-assert VW `PLTRST#` on S3 resume, causes the units to not power on in the EC code. Switch them to S0ix by default, but leave S3 available.

Ref: system76/firmware-open#469