### PR TITLE
mb/system76/adl,rpl: Add timeouts for PCIe 3.0 RPs

### DIFF
--- a/src/mainboard/system76/adl/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/darp8/overridetree.cb
@@ -154,6 +154,7 @@ chip soc/intel/alderlake
 				.clk_src = 4,
 				.clk_req = 4,
 				.flags = PCIE_RP_LTR,
+				.pcie_rp_detect_timeout_ms = 50,
 			}"
 			# FIXME: Drives do not exit D3cold on S3 exit
 			#chip soc/intel/common/block/pcie/rtd3

--- a/src/mainboard/system76/adl/variants/gaze17-3050/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/gaze17-3050/overridetree.cb
@@ -102,6 +102,7 @@ chip soc/intel/alderlake
 				.clk_src = 1,
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR,
+				.pcie_rp_detect_timeout_ms = 50,
 			}"
 		end
 		device ref pcie_rp9 on

--- a/src/mainboard/system76/adl/variants/gaze17-3060-b/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/gaze17-3060-b/overridetree.cb
@@ -134,6 +134,7 @@ chip soc/intel/alderlake
 				.clk_src = 1,
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR,
+				.pcie_rp_detect_timeout_ms = 50,
 			}"
 		end
 		device ref gbe on end

--- a/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
@@ -138,6 +138,7 @@ chip soc/intel/alderlake
 				.clk_src = 1,
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR,
+				.pcie_rp_detect_timeout_ms = 50,
 			}"
 			# FIXME: Drives do not exit D3cold on S3 exit
 			#chip soc/intel/common/block/pcie/rtd3

--- a/src/mainboard/system76/rpl/variants/gaze18/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/gaze18/overridetree.cb
@@ -63,6 +63,7 @@ chip soc/intel/alderlake
 				.clk_src = 1,
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
+				.pcie_rp_detect_timeout_ms = 50,
 			}"
 		end
 		device ref pcie_rp9 on

--- a/src/mainboard/system76/rpl/variants/lemp12/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/lemp12/overridetree.cb
@@ -79,6 +79,7 @@ chip soc/intel/alderlake
 				.clk_src = 1,
 				.clk_req = 1,
 				.flags = PCIE_RP_LTR,
+				.pcie_rp_detect_timeout_ms = 50,
 			}"
 		end
 	end


### PR DESCRIPTION
The FSP may fail to detect PCIe 4.0 devices in PCIe 3.0 slots on S3 resume. This issue has only been experienced on lemp12, and only with Samsung drives, but implies it could happen on other systems or with other drives as well.

Tested on lemp12 with Samsung 980 PRO and 990 PRO drives.