### PR TITLE
mb/system76/adl,rpl: Fix HDA codec init

### DIFF
--- a/src/mainboard/system76/adl/devicetree.cb
+++ b/src/mainboard/system76/adl/devicetree.cb
@@ -81,6 +81,7 @@ chip soc/intel/alderlake
 		end
 		device ref p2sb on end
 		device ref hda on
+			register "pch_hda_sdi_enable[0]" = "1"
 			register "pch_hda_audio_link_hda_enable" = "1"
 			register "pch_hda_idisp_codec_enable" = "1"
 			register "pch_hda_idisp_link_frequency" = "HDA_LINKFREQ_96MHZ"

--- a/src/mainboard/system76/adl/variants/lemp11/romstage.c
+++ b/src/mainboard/system76/adl/variants/lemp11/romstage.c
@@ -15,7 +15,6 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 	};
 	const bool half_populated = false;
 
-	mupd->FspmConfig.PchHdaAudioLinkHdaEnable = 1;
 	mupd->FspmConfig.DmiMaxLinkSpeed = 4;
 	mupd->FspmConfig.GpioOverride = 0;
 

--- a/src/mainboard/system76/adl/variants/oryp10/romstage.c
+++ b/src/mainboard/system76/adl/variants/oryp10/romstage.c
@@ -33,7 +33,6 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 	// Set primary display to internal graphics
 	mupd->FspmConfig.PrimaryDisplay = 0;
 
-	mupd->FspmConfig.PchHdaAudioLinkHdaEnable = 1;
 	mupd->FspmConfig.DmiMaxLinkSpeed = 4;
 	mupd->FspmConfig.GpioOverride = 0;
 

--- a/src/mainboard/system76/adl/variants/oryp9/romstage.c
+++ b/src/mainboard/system76/adl/variants/oryp9/romstage.c
@@ -30,7 +30,6 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 	// Set primary display to internal graphics
 	mupd->FspmConfig.PrimaryDisplay = 0;
 
-	mupd->FspmConfig.PchHdaAudioLinkHdaEnable = 1;
 	mupd->FspmConfig.DmiMaxLinkSpeed = 4;
 	mupd->FspmConfig.GpioOverride = 0;
 

--- a/src/mainboard/system76/rpl/devicetree.cb
+++ b/src/mainboard/system76/rpl/devicetree.cb
@@ -65,6 +65,7 @@ chip soc/intel/alderlake
 		end
 		device ref p2sb on end
 		device ref hda on
+			register "pch_hda_sdi_enable[0]" = "1"
 			register "pch_hda_audio_link_hda_enable" = "1"
 			register "pch_hda_idisp_codec_enable" = "1"
 			register "pch_hda_idisp_link_frequency" = "HDA_LINKFREQ_96MHZ"


### PR DESCRIPTION
Commit 2d482386182e ("soc/intel/alderlake: Set PchHdaSdiEnable for Alder Lake") hooked up a new UPD, overriding the FSP default and causing HDA init to break. Hook up the new UPD in the devicetree to restore HDA functionality.

Also remove PchHdaAudioLinkHdaEnable per board romstage, as it set in the devicetree.

- Ref: https://review.coreboot.org/c/coreboot/+/76449
- Ref: https://review.coreboot.org/c/coreboot/+/77125