### PR TITLE
Pick upstream SoC and RTC fixes

### DIFF
--- a/src/lib/rtc.c
+++ b/src/lib/rtc.c
@@ -126,7 +126,7 @@ static int rtc_month_days(unsigned int month, unsigned int year)
 {
 	int month_days[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
-	return month_days[month] + (LEAP_YEAR(year) && month == 2);
+	return month_days[month] + (LEAP_YEAR(year) && month == 1);
 }
 
 int rtc_invalid(const struct rtc_time *tm)

--- a/src/soc/intel/alderlake/Kconfig
+++ b/src/soc/intel/alderlake/Kconfig
@@ -560,4 +560,9 @@ config HSPHY_FW_MAX_SIZE
 config HAVE_BMP_LOGO_COMPRESS_LZMA
 	default n
 
+config SOC_INTEL_COMMON_BLOCK_ACPI_SLP_S0_FREQ_HZ
+	default 0x2005
+	help
+	  slp_s0_residency granularity in 122us ticks (i.e. ~8.2KHz).
+
 endif

--- a/src/soc/intel/alderlake/fsp_params.c
+++ b/src/soc/intel/alderlake/fsp_params.c
@@ -680,6 +680,10 @@ static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 		if (is_dev_enabled(tcss_port_arr[i]))
 			s_cfg->UsbTcPortEn |= BIT(i);
 	}
+
+#if !CONFIG(SOC_INTEL_ALDERLAKE_PCH_M)
+	s_cfg->Usb4CmMode = CONFIG(SOFTWARE_CONNECTION_MANAGER);
+#endif
 }
 
 static void fill_fsps_chipset_lockdown_params(FSP_S_CONFIG *s_cfg,

--- a/src/soc/intel/tigerlake/acpi/tcss.asl
+++ b/src/soc/intel/tigerlake/acpi/tcss.asl
@@ -363,12 +363,6 @@ Scope (\_SB.PCI0)
 		Offset(0x10),
 		RBAR, 64        /* RegBar, offset 0x7110 in MCHBAR */
 	}
-	Field (MBAR, DWordAcc, NoLock, Preserve)
-	{
-		Offset(0x304),  /* PRIMDN_MASK1_0_0_0_MCHBAR_IMPH, offset 0x7404 */
-		,     31,
-		TCD3, 1         /* [31:31] TCSS IN D3 bit */
-	}
 
 	/*
 	 * Operation region defined to access the pCode mailbox interface. Get the MCHBAR
@@ -402,101 +396,6 @@ Scope (\_SB.PCI0)
 			Return (0xFF)
 		}
 		Return (0)
-	}
-
-	/*
-	 * Method to send pCode MailBox command TCSS_DEVEN_MAILBOX_SUBCMD_GET_STATUS
-	 *
-	 * Result will be updated in DATA[1:0]
-	 * DATA[0:0] TCSS_DEVEN_CURRENT_STATE:
-	 *	0 - TCSS Deven in normal state.
-	 *	1 - TCSS Deven is cleared by BIOS Mailbox request.
-	 * DATA[1:1] TCSS_DEVEN_REQUEST_STATUS:
-	 *	0 - IDLE. TCSS DEVEN has reached its final requested state.
-	 *	1 - In Progress. TCSS DEVEN is currently in progress of switching state
-	 *	    according to given request (bit 0 reflects source state).
-	 *
-	 * Return 0x00 - TCSS Deven in normal state
-	 *	  0x01 - TCSS Deven is cleared by BIOS Mailbox request
-	 *	  0x1x - TCSS Deven is in progress of switching state according to given request
-	 *	  0xFE - Command timeout
-	 *	  0xFF - Command corrupt
-	 */
-	Method (DSGS, 0)
-	{
-		If ((PMBY () == 0)) {
-			PMBC = MAILBOX_BIOS_CMD_TCSS_DEVEN_INTERFACE
-			PSCM = TCSS_DEVEN_MAILBOX_SUBCMD_GET_STATUS
-			PMBR = 1
-			If (PMBY () == 0) {
-				Local0 = PMBD
-				Local1 = PMBC
-				Stall (10)
-				If ((Local0 != PMBD) || (Local1 != PMBC)) {
-					Printf("pCode MailBox is corrupt.")
-					Return (0xFF)
-				}
-				Return (Local0)
-			} Else {
-				Printf("pCode MailBox is not ready.")
-				Return (0xFE)
-			}
-		} Else {
-			Printf("pCode MailBox is not ready.")
-			Return (0xFE)
-		}
-	}
-
-	/*
-	 * Method to send pCode MailBox command TCSS_DEVEN_MAILBOX_SUBCMD_TCSS_CHANGE_REQ
-	 *
-	 * Arg0 : 0 - Restore to previously saved value of TCSS DEVEN
-	 *	  1 - Save current TCSS DEVEN value and clear it
-	 *
-	 * Return 0x00 - MAILBOX_BIOS_CMD_CLEAR_TCSS_DEVEN command completed
-	 *	  0xFD - Input argument is invalid
-	 *	  0xFE - Command timeout
-	 *	  0xFF - Command corrupt
-	 */
-	Method (DSCR, 1)
-	{
-		If (Arg0 > 1) {
-			Printf("pCode MailBox is corrupt.")
-			Return (0xFD)
-		}
-		If ((PMBY () == 0)) {
-			PMBC = MAILBOX_BIOS_CMD_TCSS_DEVEN_INTERFACE
-			PSCM = TCSS_DEVEN_MAILBOX_SUBCMD_TCSS_CHANGE_REQ
-			PMBD = Arg0
-			PMBR = 1
-			If ((PMBY () == 0)) {
-				Local0 = PMBD
-				Local1 = PMBC
-				Stall (10)
-				If ((Local0 != PMBD) || (Local1 != PMBC)) {
-					Printf("pCode MailBox is corrupt.")
-					Return (0xFF)
-				}
-				/* Poll TCSS_DEVEN_REQUEST_STATUS, timeout value is 10ms. */
-				Local0 = 0
-				While ((DSGS () & 0x10) && (Local0 < 100)) {
-					Stall (100)
-					Local0++
-				}
-				If (Local0 == 100) {
-					Printf("pCode MailBox is not ready.")
-					Return (0xFE)
-				} Else {
-					Return (0x00)
-				}
-			} Else {
-				Printf("pCode MailBox is not ready.")
-				Return (0xFE)
-			}
-		} Else {
-			Printf("pCode MailBox is not ready.")
-			Return (0xFE)
-		}
 	}
 
 	/*
@@ -707,26 +606,7 @@ Scope (\_SB.PCI0)
 			}
 			Else
 			{
-				/*
-				 * Program IOP MCTP Drop (TCSS_IN_D3) after D3 cold exit and
-				 * acknowledgement by IOM.
-				 */
-				TCD3 = 0
-				/*
-				 * If the TCSS Deven is cleared by BIOS Mailbox request, then
-				 * restore to previously saved value of TCSS DEVNE.
-				 */
-				Local0 = 0
-				While (\_SB.PCI0.TXHC.VDID == 0xFFFFFFFF) {
-					If (DSGS () == 1) {
-						DSCR (0)
-					}
-					Local0++
-					If (Local0 == 5) {
-						Printf("pCode mailbox command failed.")
-						Break
-					}
-				}
+				Printf("TCSS D3 exit.");
 			}
 		}
 		Else {
@@ -742,27 +622,6 @@ Scope (\_SB.PCI0)
 			Printf("Skip D3C entry.")
 			Return
 		}
-
-		/*
-		 * If the TCSS Deven in normal state, then Save current TCSS DEVEN value and
-		 * clear it.
-		 */
-		Local0 = 0
-		While (\_SB.PCI0.TXHC.VDID != 0xFFFFFFFF) {
-			If (DSGS () == 0) {
-				DSCR (1)
-			}
-			Local0++
-			If (Local0 == 5) {
-				Printf("pCode mailbox command failed.")
-				Break
-			}
-		}
-
-		/*
-		 * Program IOM MCTP Drop (TCSS_IN_D3) in D3Cold entry before entering D3 cold.
-		 */
-		TCD3 = 1
 
 		/* Request IOM for D3 cold entry sequence. */
 		TD3C = 1

--- a/src/soc/intel/tigerlake/acpi/tcss.asl
+++ b/src/soc/intel/tigerlake/acpi/tcss.asl
@@ -567,6 +567,10 @@ Scope (\_SB.PCI0)
 				/* DMA0 is not in D3Cold now. */
 				\_SB.PCI0.TDM0.D3CE()  /* Enable DMA RTD3 */
 
+				If (\_SB.PCI0.TDM0.IF30 != 1) {
+					Return
+				}
+
 				Printf("Push TBT RPs to D3Cold together")
 				If (\_SB.PCI0.TRP0.VDID != 0xFFFFFFFF) {
 					/* Put RP0 to D3 cold. */
@@ -621,6 +625,10 @@ Scope (\_SB.PCI0)
 			If (\_SB.PCI0.TDM1.STAT == 1) {
 				/* DMA1 is not in D3Cold now */
 				\_SB.PCI0.TDM1.D3CE()  /* Enable DMA RTD3. */
+
+				If (\_SB.PCI0.TDM0.IF30 != 1) {
+					Return
+				}
 
 				Printf("Push TBT RPs to D3Cold together")
 				If (\_SB.PCI0.TRP2.VDID != 0xFFFFFFFF) {

--- a/src/soc/intel/tigerlake/acpi/tcss_dma.asl
+++ b/src/soc/intel/tigerlake/acpi/tcss_dma.asl
@@ -11,7 +11,8 @@ Field (DPME, AnyAcc, NoLock, Preserve)
 	, 6,
 	PMES, 1,        /* 15, PME_STATUS */
 	Offset(0xC8),   /* 0xC8, TBT NVM FW Revision */
-	,     31,
+	,     30,
+	IF30,  1,	/* ITBT FW Version Bit30 */
 	INFR,  1,       /* TBT NVM FW Ready */
 	Offset(0xEC),   /* 0xEC, TBT TO PCIE Register */
 	TB2P, 32,       /* TBT to PCIe */


### PR DESCRIPTION
Cherry-pick the following upstream commits that have been merged since the 24.02 release:

- fb401e74da0c: [soc/intel/alderlake: Sync UPD Usb4CmMode with Kconfig](https://review.coreboot.org/c/coreboot/+/80486)
- 961ed9fe2710: [soc/intel/adl: Set slp-s0 counter frequency](https://review.coreboot.org/c/coreboot/+/80665)
- 377845a9d4f3: [soc/intel/tigerlake: Fix processor hang while plug unplug of TBT device](https://review.coreboot.org/c/coreboot/+/80718)
- 354a54ac84a9: [soc/intel/tigerlake: Remove IOM Mctp command from TCSS ASL](https://review.coreboot.org/c/coreboot/+/80719)
- adf042f6c61e: [lib/rtc: Fix off-by-one error in February day count in leap year](https://review.coreboot.org/c/coreboot/+/80790)