### PR TITLE
mb/system76/rpl: oryp12: Disable AER on TBT port

### DIFF
--- a/src/mainboard/system76/rpl/variants/oryp12/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/oryp12/overridetree.cb
@@ -108,10 +108,11 @@ chip soc/intel/alderlake
 		end
 		device ref pcie_rp25 on
 			# TBT
+			# XXX: AER causes UnsupReq warnings
 			register "pch_pcie_rp[PCH_RP(25)]" = "{
 				.clk_src = 15,
 				.clk_req = 15,
-				.flags = PCIE_RP_LTR | PCIE_RP_AER | PCIE_RP_HOTPLUG,
+				.flags = PCIE_RP_LTR | PCIE_RP_HOTPLUG,
 			}"
 			chip drivers/intel/dtbt
 				device pci 00.0 on end


### PR DESCRIPTION
This is the same issue that affects serw13. May be related to the use of the DTBT driver?