### PR TITLE
mb/system76: Update CMOS layouts

### DIFF
--- a/src/mainboard/system76/addw1/cmos.layout
+++ b/src/mainboard/system76/addw1/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/adl/cmos.layout
+++ b/src/mainboard/system76/adl/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/bonw14/cmos.layout
+++ b/src/mainboard/system76/bonw14/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/cml-u/cmos.layout
+++ b/src/mainboard/system76/cml-u/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/gaze15/cmos.layout
+++ b/src/mainboard/system76/gaze15/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/kbl-u/cmos.layout
+++ b/src/mainboard/system76/kbl-u/cmos.layout
@@ -12,7 +12,10 @@ entries
 400	8	r	0	century
 
 412	4	e	6	debug_level
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -32,4 +35,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/mtl/cmos.layout
+++ b/src/mainboard/system76/mtl/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/oryp5/cmos.layout
+++ b/src/mainboard/system76/oryp5/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/oryp6/cmos.layout
+++ b/src/mainboard/system76/oryp6/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/rpl/cmos.layout
+++ b/src/mainboard/system76/rpl/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/tgl-h/cmos.layout
+++ b/src/mainboard/system76/tgl-h/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/tgl-u/cmos.layout
+++ b/src/mainboard/system76/tgl-u/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984

--- a/src/mainboard/system76/whl-u/cmos.layout
+++ b/src/mainboard/system76/whl-u/cmos.layout
@@ -14,7 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
-904	80	h	0	ramtop
+
+# CMOS_VSTART_ramtop
+800	80	r	0	ramtop
+
 984	16	h	0	check_sum
 
 enumerations
@@ -37,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984


### PR DESCRIPTION
Use the default position for ramtop and exclude it from the checksum. Fixes invalid checksum after caching ramtop causing things like disabling CSME to not work.

upstream: [CB:81641](https://review.coreboot.org/c/coreboot/+/81641)