### PR TITLE
soc/intel/alderlake: Set UsbTcPortEn based on tcss_port[x]

### DIFF
--- a/src/soc/intel/alderlake/fsp_params.c
+++ b/src/soc/intel/alderlake/fsp_params.c
@@ -652,13 +652,6 @@ WEAK_DEV_PTR(tcss_usb3_port4);
 static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 		const struct soc_intel_alderlake_config *config)
 {
-	const struct device *tcss_port_arr[] = {
-		DEV_PTR(tcss_usb3_port1),
-		DEV_PTR(tcss_usb3_port2),
-		DEV_PTR(tcss_usb3_port3),
-		DEV_PTR(tcss_usb3_port4),
-	};
-
 	s_cfg->TcssAuxOri = config->tcss_aux_ori;
 
 	/* Explicitly clear this field to avoid using defaults */
@@ -676,8 +669,8 @@ static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 	s_cfg->D3ColdEnable = CONFIG(D3COLD_SUPPORT);
 
 	s_cfg->UsbTcPortEn = 0;
-	for (int i = 0; i < MAX_TYPE_C_PORTS; i++) {
-		if (is_dev_enabled(tcss_port_arr[i]))
+	for (int i = 0; i < ARRAY_SIZE(config->tcss_ports); i++) {
+		if (config->tcss_ports[i].enable)
 			s_cfg->UsbTcPortEn |= BIT(i);
 	}
 


### PR DESCRIPTION
UsbTcPortEn is configured based on pointers to tcss_usb3_port1, which is part of the ACPI driver.

This is illogical, as the port might need to be enabled, and the ACPI not needed or included. Change this so it's configured based on the tcss_port[x] in devicetree.

Tested by connecting a USB 3.0 hub, and checking that Linux correctly identifies a new USB 3.0 device.

Change-Id: I07ef0759057f7f40210766a73643c9ccf1dc986d
Reviewed-on: https://review.coreboot.org/c/coreboot/+/82058