### PR TITLE
soc/alderlake/romstage: Set UsbTcPortEnPreMem UPD based on devicetree

### DIFF
--- a/src/soc/intel/alderlake/romstage/fsp_params.c
+++ b/src/soc/intel/alderlake/romstage/fsp_params.c
@@ -271,6 +271,11 @@ static void fill_fspm_tcss_params(FSP_M_CONFIG *m_cfg,
 	m_cfg->TcssDma0En = is_devfn_enabled(SA_DEVFN_TCSS_DMA0);
 	m_cfg->TcssDma1En = is_devfn_enabled(SA_DEVFN_TCSS_DMA1);
 
+	m_cfg->UsbTcPortEnPreMem = 0;
+	for (int i = 0; i < MAX_TYPE_C_PORTS; i++)
+		if (config->tcss_ports[i].enable)
+			m_cfg->UsbTcPortEnPreMem |= BIT(i);
+
 #if (CONFIG(SOC_INTEL_RAPTORLAKE) && !CONFIG(FSP_USE_REPO)) || \
 	(!CONFIG(SOC_INTEL_ALDERLAKE_PCH_N) && CONFIG(FSP_USE_REPO))
 	m_cfg->DisableDynamicTccoldHandshake =


### PR DESCRIPTION
[ upstream commit ca5254acc0d55199254a270496c955249ad244d1 ]

The UsbTcPortEn UPD for FSP-S is being set in ramstage, however the equivalent FSP-M UPD, the UsbTcPortEnPreMem, was not being set. Following the Meteor Lake example, set the UsbTcPortEnPreMem UPD as well for Alder Lake.

Setting this FSP-M UPD will cause FSP to properly program sideband use BSSB_LSx pins for the enabled Type-C ports. Required for proper DCI debug and TCSS initialization flow.

Reviewed-on: https://review.coreboot.org/c/coreboot/+/80500