### PR TITLE
mb/system76/mtl: Enable NPU

### DIFF
--- a/src/mainboard/system76/mtl/devicetree.cb
+++ b/src/mainboard/system76/mtl/devicetree.cb
@@ -30,6 +30,7 @@ chip soc/intel/meteorlake
 
 			register "gfx" = "GMA_DEFAULT_PANEL(0)"
 		end
+		device ref vpu on end
 		device ref ioe_shared_sram on end
 		device ref pmc_shared_sram on end
 		device ref cnvi_wifi on


### PR DESCRIPTION
The fuck did Intel add now?

TODO: Check if it's detected/works with the NPU driver or something.

Ref: https://github.com/system76/firmware-open/issues/580