### PR TITLE
Update Intel microcode to 2024-11-12 release

### DIFF
--- a/src/soc/intel/alderlake/Makefile.mk
+++ b/src/soc/intel/alderlake/Makefile.mk
@@ -82,7 +82,7 @@ ifeq ($(CONFIG_SOC_INTEL_ALDERLAKE_PCH_S),y)
 # ADL-S/HX C0/H0 and RPL-S C0/H0
 cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-97-05
 # RPL-S/HX B0
-cpu_microcode_bins += 3rdparty/blobs/soc/intel/raptorlake/06-b7-01
+cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-b7-01
 else ifeq ($(CONFIG_SOC_INTEL_ALDERLAKE_PCH_N),y)
 cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-be-00
 else


### PR DESCRIPTION
Cherry-pick:

- 148bc36c6de2 ("3rdparty/intel-microcode: Update submodule to upstream main")
- 9dcfad722cf2 ("soc/intel/raptorlake: Fall back to Intel microcode repo")
- 672c36d71fe0 ("3rdparty/intel-microcode: Update submodule to upstream main")
- 02cbfaa20120 ("3rdparty/intel-microcode: Update submodule to upstream main")

Ref:

- https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20241112