### PR TITLE
mb/system76/meer9: Add `power_on_after_fail`

### DIFF
--- a/src/mainboard/system76/meer9/bootblock.c
+++ b/src/mainboard/system76/meer9/bootblock.c
@@ -69,6 +69,12 @@ static void superio_init(void)
 	// GPIO 87 set high
 	pnp_write_config(dev, 0xF1, 0x80); // Default is 0xFF
 
+	printk(BIOS_DEBUG, "configure ACPI (logical device A)\n");
+	dev = PNP_DEV(0x2E, 0x0A);
+	pnp_set_logical_device(dev);
+	// User-defined resume state after power loss
+	pnp_write_config(dev, 0xE4, 0x60); // Default is 0x00
+
 	printk(BIOS_DEBUG, "configure hardware monitor (logical device B)\n");
 	dev = PNP_DEV(0x2E, 0x0B);
 	pnp_set_logical_device(dev);

--- a/src/mainboard/system76/meer9/cmos.default
+++ b/src/mainboard/system76/meer9/cmos.default
@@ -3,3 +3,4 @@
 boot_option=Fallback
 debug_level=Debug
 me_state=Enable
+power_on_after_fail=Disable

--- a/src/mainboard/system76/meer9/cmos.layout
+++ b/src/mainboard/system76/meer9/cmos.layout
@@ -11,6 +11,8 @@ entries
 # RTC_CLK_ALTCENTURY
 400	8	r	0	century
 
+# TODO: Use enum 7 to allow `Keep`
+409	2	e	1	power_on_after_fail
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
@@ -21,6 +23,9 @@ entries
 984	16	h	0	check_sum
 
 enumerations
+
+1	0	Disable
+1	1	Enable
 
 2	0	Enable
 2	1	Disable
@@ -37,6 +42,10 @@ enumerations
 6	6	Info
 6	7	Debug
 6	8	Spew
+
+7	0	Disable
+7	1	Enable
+7	2	Keep
 
 checksums
 


### PR DESCRIPTION
Configure SuperIO for BIOS control of power loss behavior and add CMOS option to allow user control.

Enum 1 is used instead of 7 as the `Keep` option does not seem to work on meer9. The same setting via SIO control (`CRE4`) does work, though.

### Test

With default value of `Disable`:

- Unit remains off after unplugging and plugging AC power while on or off

With value of `Enable`:

- Unit turns back on after unplugging and plugging AC power while on or off