### PR TITLE
Improvements to the meer9 fan curve

### DIFF
--- a/src/mainboard/system76/meer9/bootblock.c
+++ b/src/mainboard/system76/meer9/bootblock.c
@@ -146,23 +146,23 @@ static void hm_init(void)
 	// CPUFAN FD1 = 25% = 0x3F
 	hm_write(0x74, 0x3F);
 
-	// CPUFAN T2 = 70C
-	hm_write(0x71, 70);
+	// CPUFAN T2 = 75C
+	hm_write(0x71, 75);
 	// CPUFAN FD2 = 50% = 0x7F
 	hm_write(0x75, 0x7F);
 
-	// CPUFAN T3 = 80C
-	hm_write(0x72, 80);
-	// CPUFAN FD3 = 65% = 0xA5
-	hm_write(0x76, 0xA5);
+	// CPUFAN T3 = 90C
+	hm_write(0x72, 90);
+	// CPUFAN FD3 = 75% = 0xBF
+	hm_write(0x76, 0xBF);
 
-	// CPUFAN T4 = 90C
-	hm_write(0x73, 90);
-	// CPUFAN FD4 = 85% = 0xD8
-	hm_write(0x77, 0xD8);
+	    // CPUFAN T4 = 99C
+	hm_write(0x73, 99);
+	// CPUFAN FD4 = 100% = 0xFF
+	hm_write(0x77, 0xFF);
 
-	// CPUFAN critical temperature = 95C
-	hm_write(0x2A, 95);
+	// CPUFAN critical temperature = 105C
+	hm_write(0x2A, 105);
 	// By default critical duty is 0xFF
 
 	// CPUFAN step up time = 1s

--- a/src/mainboard/system76/meer9/devicetree.cb
+++ b/src/mainboard/system76/meer9/devicetree.cb
@@ -3,7 +3,7 @@ chip soc/intel/meteorlake
 	register "eist_enable" = "1"
 
 	# Thermal
-	register "tcc_offset" = "1" # 110C - 1C = 109C
+	register "tcc_offset" = "11" # 110C - 11C = 99C
 
 	device cpu_cluster 0 on end
 


### PR DESCRIPTION
- Curve increases more gradually
- TCC is adjusted to 99C
- Critical temperature is 105C, above TCC point
- Curve reaches 100% gradually at 99C instead of triggering critical fan duty at 95C

![meer9-fan-curve](https://github.com/user-attachments/assets/9bdb0ad5-f09a-4214-a875-710172ed208d)
