### PR TITLE
drivers/gfx/nvidia: NVPCF updates

### DIFF
--- a/src/drivers/gfx/nvidia/Kconfig
+++ b/src/drivers/gfx/nvidia/Kconfig
@@ -1,6 +1,7 @@
 config DRIVERS_GFX_NVIDIA
 	bool
 	default n
+	depends on HAVE_ACPI_TABLES
 	help
 	  Support for NVIDIA Optimus graphics
 

--- a/src/drivers/gfx/nvidia/acpi/common/nvpcf.asl
+++ b/src/drivers/gfx/nvidia/acpi/common/nvpcf.asl
@@ -1,113 +1,206 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
 #define NVPCF_DSM_GUID "36b49710-2483-11e7-9598-0800200c9a66"
-#define NVPCF_REVISION_ID 0x00000200
-#define NVPCF_ERROR_SUCCESS 0x0
-#define NVPCF_ERROR_GENERIC 0x80000001
-#define NVPCF_ERROR_UNSUPPORTED 0x80000002
-#define NVPCF_FUNC_GET_SUPPORTED 0x00000000
-#define NVPCF_FUNC_GET_STATIC_CONFIG_TABLES 0x00000001
-#define NVPCF_FUNC_UPDATE_DYNAMIC_PARAMS 0x00000002
+#define NVPCF_REVISION_ID 0x200
 
-Name(_HID, "NVDA0820")
+#define NVPCF_ERROR_SUCCESS	0
+#define NVPCF_ERROR_GENERIC	0x80000001
+#define NVPCF_ERROR_UNSUPPORTED	0x80000002
 
-Name(_UID, "NPCF")
+#define NVPCF_FUNC_GET_SUPPORTED			0 // Required
+#define NVPCF_FUNC_GET_STATIC_CONFIG_TABLES		1 // Required
+#define NVPCF_FUNC_UPDATE_DYNAMIC_PARAMS		2 // Required
+#define NVPCF_FUNC_GET_WM2_TBAND_TABLES			3
+#define NVPCF_FUNC_GET_WM2_SL_MAP_TABLES		4
+#define NVPCF_FUNC_GET_WM2_DYNAMIC_PARAMS		5
+#define NVPCF_FUNC_CPU_CONTROL				6
+#define NVPCF_FUNC_GPU_INFO				7
+#define NVPCF_FUNC_GET_DC_SYSTEM_POWER_LIMITS_TABLE	8
+#define NVPCF_FUNC_CPU_TDP_CONTROL			9
+#define NVPCF_FUNC_GET_DC_TPP_LIMIT_PREFERENCE		10
+#define NVPCF_FUNC_GET_THERMAL_ZONE_STATUS		11
 
-Method(_DSM, 4, Serialized) {
-	Printf("NVPCF _DSM")
-	If (Arg0 == ToUUID(NVPCF_DSM_GUID)) {
-		If (ToInteger(Arg1) == NVPCF_REVISION_ID) {
-			Return(NPCF(Arg2, Arg3))
-		} Else {
-			Printf("  Unsupported NVPCF revision: %o", SFST(Arg1))
-			Return(NVPCF_ERROR_GENERIC)
-		}
-	} Else {
-		Printf("  Unsupported GUID: %o", IDST(Arg0))
-		Return(NVPCF_ERROR_GENERIC)
-	}
+Name (DBAC, 0) // Disable GPU Boost on AC
+Name (DBDC, 0) // Disable GPU Boost on DC (XXX: Proprietary default disables on DC)
+
+Name (_HID, "NVDA0820")
+Name (_UID, "NPCF")
+
+Method (_STA, 0, NotSerialized)
+{
+	Return (0x0F) // ACPI_STATUS_DEVICE_ALL_ON
 }
 
-Method(NPCF, 2, Serialized) {
-	Printf("  NVPCF NPCF")
-	Switch(ToInteger(Arg0)) {
-		Case(NVPCF_FUNC_GET_SUPPORTED) {
-			Printf("    Supported Functions")
-			Return(ITOB(
+Method (_DSM, 4, Serialized)
+{
+	If (Arg0 == ToUUID (NVPCF_DSM_GUID)) {
+		Printf ("NVPCF DSM")
+		If (ToInteger (Arg1) == NVPCF_REVISION_ID) {
+			Return (NPCF (Arg2, Arg3))
+		} Else {
+			Printf ("  NVPCF: Unsupported revision: %o", Arg1)
+		}
+	}
+	Else {
+		Printf ("  NVPCF: Unsupported GUID: %o", IDST (Arg0))
+	}
+
+	Return (NVPCF_ERROR_GENERIC)
+}
+
+Method (NPCF, 2, Serialized)
+{
+	Switch (ToInteger (Arg0)) {
+		Case (NVPCF_FUNC_GET_SUPPORTED) {
+			Printf ("  NVPCF[0]: GET_SUPPORTED")
+			Return (ITOB (
 				(1 << NVPCF_FUNC_GET_SUPPORTED) |
 				(1 << NVPCF_FUNC_GET_STATIC_CONFIG_TABLES) |
 				(1 << NVPCF_FUNC_UPDATE_DYNAMIC_PARAMS)
 			))
 		}
-		Case(NVPCF_FUNC_GET_STATIC_CONFIG_TABLES) {
-			Printf("    Get Static Config")
-			Return(Buffer(14) {
-				// Device table header
+		Case (NVPCF_FUNC_GET_STATIC_CONFIG_TABLES) {
+			Printf ("  NVPCF[1]: GET_STATIC_CONFIG_TABLE")
+			Return (Buffer (14) {
+				// System Device Table Header (v2.0)
 				0x20, 0x03, 0x01,
-				// Intel + NVIDIA
+				// System Device Table Entries
+				//   [3:0] CPU Type (0=Intel, 1=AMD)
+				//   [7:4] GPU Type (0=Nvidia)
 				0x00,
-				// Controller table header
+				// System Controller Table Header (v2.3)
 				0x23, 0x04, 0x05, 0x01,
-				// Dynamic boost controller
+				// System Controller Table Controller Entry
+				// Controller Flags
+				//   [3:0] Controller Class Type
+				//      0=Disabled
+				//      1=Dynamic Boost Controller
+				//      2=Configurable TGP-only Controller
+				//   [7:4] Reserved
 				0x01,
-				// Supports DC
-				0x01,
-				// Reserved
-				0x00, 0x00, 0x00,
-				// Checksum
+				// Controller Params
+				//   [0:0] DC support (0=Not supported, 1=Supported)
+				//   [31:1] Reserved
+				0x01, 0x00, 0x00, 0x00,
+				// Single byte checksum value
 				0xAD
 			})
 		}
-		Case(NVPCF_FUNC_UPDATE_DYNAMIC_PARAMS) {
-			Printf("    Update Dynamic Boost")
+		Case (NVPCF_FUNC_UPDATE_DYNAMIC_PARAMS) {
+			Printf ("  NVPCF[2]: UPDATE_DYNAMIC_PARAMS")
 
-			CreateField(Arg1, 0x28, 2, ICMD) // Input command
+			// Dynamic Params Common Status, Input
+			//   0=Get Controller Params
+			//   1=Set Controller Status
+			CreateField (Arg1, 0x28, 2, ICMD)
 
-			Name(PCFP, Buffer(49) {
-				// Table version
-				0x23,
-				// Table header size
-				0x05,
-				// Size of common status in bytes
-				0x10,
-				// Size of controller entry in bytes
-				0x1C,
-				// Other fields filled in later
+			// XXX: All input params unused?
+			// Controller Entry, Input
+			//CreateByteField (Arg1, 0x15, IIDX) // Controller index
+			//CreateField (Arg1, 0xB0, 0x01, PWCS) // Power control capability (0=Disabled, 1=Enabled)
+			//CreateField (Arg1, 0xB1, 0x01, PWTS) // Power transfer status (0=Disabled, 1=Enabled)
+			//CreateField (Arg1, 0xB2, 0x01, CGPS) // CTGP status (0=Disabled, 1=Enabled)
+
+			Name (PBD2, Buffer(49) {
+				// Dynamic Params Table Header
+				0x23, // Version 2.3
+				0x05, // Table header size in bytes
+				0x10, // Size of Common Status in bytes
+				0x1C, // Size of Controller Entry in bytes
+				0x01, // Number of Controller Entries
 			})
-			CreateByteField(PCFP, 0x04, CCNT) // Controller count
-			CreateWordField(PCFP, 0x19, ATPP) // AC TPP offset
-			CreateWordField(PCFP, 0x1D, AMXP) // AC maximum TGP offset
-			CreateWordField(PCFP, 0x21, AMNP) // AC minimum TGP offset
 
-			Switch(ToInteger(ICMD)) {
-				Case(0) {
-					Printf("      Get Controller Params")
-					// Number of controllers
-					CCNT = 1
-					// AC total processor power offset from default TGP in 1/8 watt units
-					ATPP = (CONFIG_DRIVERS_GFX_NVIDIA_DYNAMIC_BOOST_TPP << 3)
-					// AC maximum TGP offset from default TGP in 1/8 watt units
-					AMXP = (CONFIG_DRIVERS_GFX_NVIDIA_DYNAMIC_BOOST_MAX << 3)
-					// AC minimum TGP offset from default TGP in 1/8 watt units
-					AMNP = (CONFIG_DRIVERS_GFX_NVIDIA_DYNAMIC_BOOST_MIN << 3)
-					Printf("PCFP: %o", SFST(PCFP))
-					Return(PCFP)
+			// Dynamic Params Common Status, Output
+			// Baseline (configurable) TGP in AC for the intended TPP
+			// limit, expressed as a signed offset relative to the
+			// static TGP rates, AC, in 1/8-watt units.
+			CreateWordField (PBD2, 0x05, TGPA)
+
+			// Controller Entry, Output - Dynamic Boost Controller
+			CreateByteField (PBD2, 0x15, OIDX) // Controller index
+			// Disable controller on AC/DC
+			//   [0:0] Disable controller on AC (0=Enable, 1=Disable)
+			//   [1:1] Disable controller on DC (0=Enable, 1=Disable)
+			CreateByteField (PBD2, 0x16, PC02)
+			CreateWordField (PBD2, 0x19, TPPA) // TPP target on AC
+			CreateWordField (PBD2, 0x1D, MAGA) // Max TGP on AC
+			CreateWordField (PBD2, 0x21, MIGA) // Min TGP on AC
+			CreateDWordField (PBD2, 0x25, DROP) // DC Rest of system reserved power
+			CreateDWordField (PBD2, 0x29, LTBC) // Long Timescale Battery Current Limit
+			CreateDWordField (PBD2, 0x2D, STBC) // Short Timescale Battery Current Limit
+
+			Switch (ToInteger (ICMD)) {
+				Case (0) {
+					Printf ("    Get Controller Params")
+
+					TGPA = 0
+					OIDX = 0
+					PC02 = DBAC | (DBDC << 1)
+					TPPA = (CONFIG_DRIVERS_GFX_NVIDIA_DYNAMIC_BOOST_TPP << 3)
+					MAGA = (CONFIG_DRIVERS_GFX_NVIDIA_DYNAMIC_BOOST_MAX << 3)
+					MIGA = (CONFIG_DRIVERS_GFX_NVIDIA_DYNAMIC_BOOST_MIN << 3)
+
+					// TODO: Handle v2.3+ fields
+
+					Printf ("PBD2: %o", SFST(PBD2))
+					Return (PBD2)
 				}
-				Case(1) {
-					Printf("      Set Controller Status")
-					//TODO
-					Printf("PCFP: %o", SFST(PCFP))
-					Return(PCFP)
+				Case (1) {
+					Printf ("    Set Controller Status")
+
+					// XXX: Match proprietary firmware behavior,
+					// which just explicitly sets fields to zero.
+					TGPA = 0
+					OIDX = 0
+					PC02 = 0
+					TPPA = 0
+					MAGA = 0
+					MIGA = 0
+
+					Printf ("PBD2: %o", SFST(PBD2))
+					Return (PBD2)
 				}
 				Default {
-					Printf("      Unknown Input Command: %o", SFST(ICMD))
-					Return(NV_ERROR_UNSUPPORTED)
+					Printf ("      Unknown Input Command: %o", SFST(ICMD))
+					Return (NV_ERROR_UNSUPPORTED)
 				}
 			}
 		}
+		Case (NVPCF_FUNC_GET_WM2_TBAND_TABLES) {
+			Printf ("  NVPCF[3]: GET_WM2_TBAND_TABLES")
+		}
+		Case (NVPCF_FUNC_GET_WM2_SL_MAP_TABLES) {
+			Printf ("  NVPCF[4]: GET_WM2_SL_MAP_TABLES")
+		}
+		Case (NVPCF_FUNC_GET_WM2_DYNAMIC_PARAMS) {
+			Printf ("  NVPCF[5]: GET_WM2_DYNAMIC_PARAMS")
+		}
+		Case (NVPCF_FUNC_CPU_CONTROL) {
+			Printf ("  NVPCF[6]: CPU_CONTROL")
+		}
+		Case (NVPCF_FUNC_GPU_INFO) {
+			Printf ("  NVPCF[7]: GPU_INFO")
+		}
+		Case (NVPCF_FUNC_GET_DC_SYSTEM_POWER_LIMITS_TABLE) {
+			Printf ("  NVPCF[8]: GET_DC_SYSTEM_POWER_LIMITS_TABLE")
+		}
+		Case (NVPCF_FUNC_CPU_TDP_CONTROL) {
+			Printf ("  NVPCF[9]: CPU_TDP_CONTROL")
+		}
+		Case (NVPCF_FUNC_GET_DC_TPP_LIMIT_PREFERENCE) {
+			Printf ("  NVPCF[10]: GET_DC_TPP_LIMIT_PREFERENCE")
+		}
+		Case (NVPCF_FUNC_GET_THERMAL_ZONE_STATUS) {
+			Printf ("  NVPCF[11]: GET_THERMAL_ZONE_STATUS")
+		}
 		Default {
-			Printf("    Unsupported function: %o", SFST(Arg0))
-			Return(NVPCF_ERROR_UNSUPPORTED)
+			Printf ("  NVPCF: Unknown function: %o", Arg0)
 		}
 	}
+
+	// XXX: DG says unsupported functions should return a
+	// buffer, but even the example immediately following
+	// this statement returns a DWORD, and this is what
+	// proprietary firmware also does.
+	Return (NVPCF_ERROR_UNSUPPORTED)
 }

--- a/src/drivers/gfx/nvidia/nvidia.c
+++ b/src/drivers/gfx/nvidia/nvidia.c
@@ -42,16 +42,13 @@ static struct pci_operations nvidia_device_ops_pci = {
 };
 
 static struct device_operations nvidia_device_ops = {
-	.read_resources   = nvidia_read_resources,
-	.set_resources    = pci_dev_set_resources,
-	.enable_resources = pci_dev_enable_resources,
-#if CONFIG(HAVE_ACPI_TABLES)
+	.read_resources    = nvidia_read_resources,
+	.set_resources     = pci_dev_set_resources,
+	.enable_resources  = pci_dev_enable_resources,
 	.write_acpi_tables = pci_rom_write_acpi_tables,
 	.acpi_fill_ssdt    = pci_rom_ssdt,
-#endif
-	.init             = pci_dev_init,
-	.ops_pci          = &nvidia_device_ops_pci,
-
+	.init              = pci_dev_init,
+	.ops_pci           = &nvidia_device_ops_pci,
 };
 
 static void nvidia_enable(struct device *dev)


### PR DESCRIPTION
- Require ACPI for the driver
- Add more inline docs
- Add `_STA` method
- Update field names to better match names from Clevo dumps/DG samples
- Add fields for v2.4 (unimplemented)
- Add `TGPA` field for `UPDATE_DYNAMIC_PARAMS`
- Match proprietary behavior for "Set Controller Status"
- Add objects for disabling boost on AC/DC
- Add debug logs for unimplemented functions