### PR TITLE
mb/system76/rpl: gaze20: Support up to 6400 MT/s memory

### DIFF
--- a/src/mainboard/system76/rpl/variants/gaze20/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/gaze20/overridetree.cb
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 chip soc/intel/alderlake
+	register "max_dram_speed_mts" = "6400"
+
 	device domain 0 on
 		subsystemid 0x1558 0x2560 inherit
 


### PR DESCRIPTION
- Does 6400 MT/s work, or should it be limited to 5600 MT/s like other models?
- Should other models be increased to 6400 MT/s?