### PR TITLE
soc/intel/adl: Only use channel 0 for mem-down DDR4

### DIFF
--- a/src/soc/intel/alderlake/meminit.c
+++ b/src/soc/intel/alderlake/meminit.c
@@ -54,8 +54,8 @@ static const struct soc_mem_cfg soc_mem_cfg[] = {
 			 * configuration.
 			 */
 			.half_channel = BIT(0),
-			/* In mixed topologies, either channel 0 or 1 can be memory-down. */
-			.mixed_topo = BIT(0) | BIT(1),
+			/* In mixed topologies, channel 0 is memory-down. */
+			.mixed_topo = BIT(0),
 		},
 	},
 	[MEM_TYPE_DDR5] = {


### PR DESCRIPTION
Apply c0ba1166e97d to DDR4.

Fixes meminit on lemp11 without a DIMM installed.