### PR TITLE
mb/system76/mtl: Fix TCP2 DDI mapping

### DIFF
--- a/src/mainboard/system76/mtl/devicetree.cb
+++ b/src/mainboard/system76/mtl/devicetree.cb
@@ -25,7 +25,7 @@ chip soc/intel/meteorlake
 			register "ddi_port_A_config" = "1"
 			register "ddi_ports_config" = "{
 				[DDI_PORT_A] = DDI_ENABLE_HPD,
-				[DDI_PORT_2] = DDI_ENABLE_HPD | DDI_ENABLE_DDC,
+				[DDI_PORT_3] = DDI_ENABLE_HPD | DDI_ENABLE_DDC,
 			}"
 
 			register "gfx" = "GMA_DEFAULT_PANEL(0)"


### PR DESCRIPTION
upstream: https://review.coreboot.org/c/coreboot/+/93284

- HDMI uses TCP2. Type-C ports are 0-indexed
- `HDMI_HPD` is connected to `DDSP_HPD2`. Since MTL, DDSP is also 0-indexed, but port mappings remain 1-indexed.

Does HDMI HPD work on MTL boards?

---

Do TBT/USB-C need to be added to `ddi_ports_config` as well?

Intel also just pushed this for Google Atria (NVL)

- https://review.coreboot.org/c/coreboot/+/93280
- https://review.coreboot.org/c/coreboot/+/93282

TCP[0-2] are used, but not declared in the FSP config. Only eDP on DDI-A and HDMI on "DDI-4", which I can only assume is TCP3.