### PR TITLE
mb/system76: Add/Fix USB xHCI ACPI configs

### DIFF
--- a/src/mainboard/system76/adl/variants/darp8/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/darp8/overridetree.cb
@@ -49,7 +49,7 @@ chip soc/intel/alderlake
 				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A Multi Board */
 				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 (USB 3.2 Gen 2) */
 				[4] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
-				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC2 (Thunderbolt) */
+				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
@@ -58,21 +58,20 @@ chip soc/intel/alderlake
 				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 CH1 */
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 CH2 */
 			}"
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 UJ_USB1""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_1""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC1""
+						register "desc" = ""USB2 Port 3""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port3 on end
 					end
@@ -82,7 +81,7 @@ chip soc/intel/alderlake
 						device ref usb2_port5 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC2""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port6 on end
 					end
@@ -97,18 +96,18 @@ chip soc/intel/alderlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_1""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_TYPEC1 CH0""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_TYPEC1 CH1""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port3 on end
 					end
 				end

--- a/src/mainboard/system76/adl/variants/galp6/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/galp6/overridetree.cb
@@ -54,7 +54,7 @@ chip soc/intel/alderlake
 				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 */
 				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1 */
 				[4] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
-				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC2 */
+				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
@@ -63,21 +63,20 @@ chip soc/intel/alderlake
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A */
 				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C */
 			}"
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_2""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC1""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_1""
+						register "desc" = ""USB2 Port 3""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port3 on end
 					end
@@ -87,7 +86,7 @@ chip soc/intel/alderlake
 						device ref usb2_port5 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC2""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port6 on end
 					end
@@ -102,18 +101,18 @@ chip soc/intel/alderlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_2""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_1""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port3 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_TYPEC1""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port4 on end
 					end
 				end

--- a/src/mainboard/system76/adl/variants/gaze17-3050/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/gaze17-3050/overridetree.cb
@@ -98,6 +98,65 @@ chip soc/intel/alderlake
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 */
 				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 5""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 6""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 9""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 		device ref pcie_rp5 on
 			# PCIe RP#5 x4, Clock 1 (SSD)

--- a/src/mainboard/system76/adl/variants/gaze17-3060-b/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/gaze17-3060-b/overridetree.cb
@@ -91,19 +91,73 @@ chip soc/intel/alderlake
 		device ref tcss_dma0 on end
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Type-A audio board */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* USB 3.2 Type-C */
-				[5] = USB2_PORT_MID(OC_SKIP),		/* USB 2.0 Type-A audio board */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 audio board */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.2 */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* Type-A 2.0 audio board */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt Type-C */
+				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Type-A audio board */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Type-C side A */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Type-C side B */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 audio board */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 side A */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 side B */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 6""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 		device ref pcie_rp5 on
 			# PCIe root port #5 x1, Clock 2 (WLAN)

--- a/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/lemp11/overridetree.cb
@@ -45,36 +45,35 @@ chip soc/intel/alderlake
 			register "usb2_ports" = "{
 				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A Left */
 				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A Right */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 */
-				[3] = USB2_PORT_MID(OC_SKIP),		/* 3G/LTE */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* WWAN */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
 				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A Left */
 				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A Right */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* 3G/LTE */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* WWAN */
 			}"
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 Type-A Left""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 Type-A Right""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 Type-C""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port3 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 3G/LTE""
+						register "desc" = ""USB2 WWAN""
 						register "type" = "UPC_TYPE_INTERNAL"
 						device ref usb2_port4 on end
 					end
@@ -89,19 +88,19 @@ chip soc/intel/alderlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 Type-A Left""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 Type-A Right""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 Type-C""
-						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
-						device ref usb3_port3 on end
+						register "desc" = ""USB3 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb3_port4 on end
 					end
 				end
 			end

--- a/src/mainboard/system76/adl/variants/oryp10/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/oryp10/overridetree.cb
@@ -73,40 +73,39 @@ chip soc/intel/alderlake
 		end
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_TYPE_C(OC_SKIP),	/* TYPEC1 (USB 3.2 Gen2) */
+				[0] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.2 Gen 2 */
 				[1] = USB2_PORT_MID(OC_SKIP),		/* J_USB2 */
 				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB1 */
-				[5] = USB2_PORT_MID(OC_SKIP),		/* Per-KB */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* TYPEC2 (Thunderbolt) */
+				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* TYPEC1 (USB 3.2 Gen2) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 */
 				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB2 */
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB1 */
 			}"
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 TYPEC1""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB2""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB1""
+						register "desc" = ""USB2 Port 3""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port3 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 Per-KB""
+						register "desc" = ""USB2 KBLED""
 						register "type" = "UPC_TYPE_INTERNAL"
 						device ref usb2_port6 on end
 					end
@@ -121,7 +120,7 @@ chip soc/intel/alderlake
 						device ref usb2_port8 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 TYPEC2""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port9 on end
 					end
@@ -131,18 +130,18 @@ chip soc/intel/alderlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 TYPEC1""
+						register "desc" = ""USB3 Port 1""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB2""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB2""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port3 on end
 					end
 				end

--- a/src/mainboard/system76/adl/variants/oryp9/overridetree.cb
+++ b/src/mainboard/system76/adl/variants/oryp9/overridetree.cb
@@ -73,40 +73,39 @@ chip soc/intel/alderlake
 		end
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_TYPE_C(OC_SKIP),	/* TYPEC1 (USB 3.2 Gen2) */
+				[0] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.2 Gen 2 */
 				[1] = USB2_PORT_MID(OC_SKIP),		/* J_USB2 */
 				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB1 */
-				[5] = USB2_PORT_MID(OC_SKIP),		/* Per-KB */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* TYPEC2 (Thunderbolt) */
+				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* TYPEC1 (USB 3.2 Gen2) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 */
 				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB2 */
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB1 */
 			}"
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 TYPEC1""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB2""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB1""
+						register "desc" = ""USB2 Port 3""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port3 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 Per-KB""
+						register "desc" = ""USB2 KBLED""
 						register "type" = "UPC_TYPE_INTERNAL"
 						device ref usb2_port6 on end
 					end
@@ -121,7 +120,7 @@ chip soc/intel/alderlake
 						device ref usb2_port8 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 TYPEC2""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb2_port9 on end
 					end
@@ -131,18 +130,18 @@ chip soc/intel/alderlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 TYPEC1""
+						register "desc" = ""USB3 Port 1""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB2""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB2""
-						register "type" = "UPC_TYPE_A"
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port3 on end
 					end
 				end

--- a/src/mainboard/system76/mtl/variants/darp10/overridetree.cb
+++ b/src/mainboard/system76/mtl/variants/darp10/overridetree.cb
@@ -31,7 +31,7 @@ chip soc/intel/meteorlake
 				[0] = USB2_PORT_MID(OC_SKIP),	/* J_AUD1 / AJ_USB3_1 */
 				[1] = USB2_PORT_MID(OC_SKIP),	/* J_TYPEC1 */
 				[2] = USB2_PORT_MID(OC_SKIP),	/* J_USB3_1 */
-				[5] = USB2_PORT_MID(OC_SKIP),	/* TBT */
+				[5] = USB2_PORT_MID(OC_SKIP),	/* Thunderbolt */
 				[6] = USB2_PORT_MID(OC_SKIP),	/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),	/* Bluetooth */
 			}"
@@ -39,6 +39,50 @@ chip soc/intel/meteorlake
 				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_AUD1 / AJ_USB3_1 */
 				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1 */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port2 on end
+					end
+				end
+			end
 		end
 		device ref i2c0 on
 			# Touchpad I2C bus

--- a/src/mainboard/system76/mtl/variants/darp11/overridetree.cb
+++ b/src/mainboard/system76/mtl/variants/darp11/overridetree.cb
@@ -31,7 +31,7 @@ chip soc/intel/meteorlake
 				[0] = USB2_PORT_MID(OC_SKIP),	/* J_AUD1 / AJ_USB3_1 */
 				[1] = USB2_PORT_MID(OC_SKIP),	/* J_TYPEC1 */
 				[2] = USB2_PORT_MID(OC_SKIP),	/* J_USB3_1 */
-				[5] = USB2_PORT_MID(OC_SKIP),	/* TBT */
+				[5] = USB2_PORT_MID(OC_SKIP),	/* Thunderbolt */
 				[6] = USB2_PORT_MID(OC_SKIP),	/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),	/* Bluetooth */
 			}"
@@ -39,6 +39,50 @@ chip soc/intel/meteorlake
 				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_AUD1 / AJ_USB3_1 */
 				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1 */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port2 on end
+					end
+				end
+			end
 		end
 		device ref i2c0 on
 			# Touchpad I2C bus

--- a/src/mainboard/system76/mtl/variants/lemp13/overridetree.cb
+++ b/src/mainboard/system76/mtl/variants/lemp13/overridetree.cb
@@ -41,16 +41,77 @@ chip soc/intel/meteorlake
 		device ref tcss_dma0 on end
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* TODO: USB TYPEA port1 GEN2 */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* TODO: USB TYPEA port2 GEN1 */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* TODO: TBT TYPEC USB2.0 */
-				[4] = USB2_PORT_TYPE_C(OC_SKIP),	/* TODO: TYPEC USB2.0 */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 1 */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* WWAN */
+				[4] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.2 Gen 2 */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* TODO: USB port1 GEN1 */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* WWAN */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						#register "use_custom_pld" = "true"
+						#register "custom_pld" = "ACPI_PLD_TYPE_A(LEFT, LEFT, ACPI_PLD_GROUP(, 4))"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						#register "use_custom_pld" = "true"
+						#register "custom_pld" = "ACPI_PLD_TYPE_A(RIGHT, CENTER, ACPI_PLD_GROUP(, 2))"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						#register "use_custom_pld" = "true"
+						#register "custom_pld" = "ACPI_PLD_TYPE_C(LEFT, LEFT, ACPI_PLD_GROUP(, 5))"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 5""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						#register "use_custom_pld" = "true"
+						#register "custom_pld" = "ACPI_PLD_TYPE_C(LEFT, LEFT, ACPI_PLD_GROUP(, 2))"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						#register "use_custom_pld" = "true"
+						#register "custom_pld" = "ACPI_PLD_TYPE_A(RIGHT, CENTER, ACPI_PLD_GROUP(, 2))"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb3_port2 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/addw3/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/addw3/overridetree.cb
@@ -18,13 +18,62 @@ chip soc/intel/alderlake
 				[2] = USB2_PORT_MID(OC_SKIP),		/* Type-C 3.2 Gen 2 (Rear) */
 				[8] = USB2_PORT_MID(OC_SKIP),		/* Type-C Thunderbolt (Right) */
 				[10] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[11] = USB2_PORT_MID(OC_SKIP),		/* Secure Pad */
+				[11] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[13] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
 				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 (Left) */
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (Rear) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port11 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port12 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/addw4/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/addw4/overridetree.cb
@@ -26,6 +26,65 @@ chip soc/intel/alderlake
 				[2] = USB3_PORT_DEFAULT(OC_SKIP), /* J_USB2 */
 				[3] = USB3_PORT_DEFAULT(OC_SKIP), /* J_USB1 (Audio board) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 4""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/bonw15-b/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/bonw15-b/overridetree.cb
@@ -10,7 +10,7 @@ chip soc/intel/alderlake
 				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Left, Front) */
 				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Left, Rear) */
 				[5] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[6] = USB2_PORT_MID(OC_SKIP),		/* Per-key RGB */
+				[6] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
 				/* Port reset messaging cannot be used,
 				 * so do not use USB2_PORT_TYPE_C for these */
 				[8] = USB2_PORT_MID(OC_SKIP),		/* Type-C Thunderbolt (Right, Front) */
@@ -21,6 +21,55 @@ chip soc/intel/alderlake
 				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Left, Front) */
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Left, Rear) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 KBLED""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port3 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/bonw15/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/bonw15/overridetree.cb
@@ -9,20 +9,69 @@ chip soc/intel/alderlake
 
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Left, Front) */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Left, Rear) */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Left, Right) */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Left, Left) */
 				[5] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[6] = USB2_PORT_MID(OC_SKIP),		/* Per-key RGB */
+				[6] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
 				/* Port reset messaging cannot be used,
 				 * so do not use USB2_PORT_TYPE_C for these */
-				[8] = USB2_PORT_MID(OC_SKIP),		/* Type-C Thunderbolt (Right, Front) */
-				[9] = USB2_PORT_MID(OC_SKIP),		/* Type-C Thunderbolt with PD (Right, Rear) */
+				[8] = USB2_PORT_MID(OC_SKIP),		/* Type-C Thunderbolt (Right, Left) */
+				[9] = USB2_PORT_MID(OC_SKIP),		/* Type-C Thunderbolt with PD (Right, Right) */
 				[13] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Left, Front) */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Left, Rear) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Left, Right) */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Left, Left) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 KBLED""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port3 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/darp9/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/darp9/overridetree.cb
@@ -57,6 +57,60 @@ chip soc/intel/alderlake
 				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 CH0 */
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 CH1 */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+				end
+			end
 		end
 		device ref i2c0 on
 			# Touchpad I2C bus

--- a/src/mainboard/system76/rpl/variants/galp7/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/galp7/overridetree.cb
@@ -24,19 +24,73 @@ chip soc/intel/alderlake
 		device ref tcss_dma0 on end
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_2 (USB 3.2 Gen1) */
-				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 (USB 3.2 Gen2) */
-				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1 (USB 3.2 Gen1) */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_2: Type-A 3.2 Gen 1 */
+				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 */
+				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1: Type-A 3.2 Gen 1 */
 				[4] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
-				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC2 (Thunerbolt) */
+				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC2: Thunderbolt */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_2 (USB 3.2 Gen1) */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1 (USB 3.2 Gen1) */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 (USB 3.2 Gen2) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_2: Type-A 3.2 Gen 1 */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1: Type-A 3.2 Gen 1 */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 		device ref i2c0 on
 			# Touchpad I2C bus

--- a/src/mainboard/system76/rpl/variants/gaze18/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/gaze18/overridetree.cb
@@ -6,20 +6,79 @@ chip soc/intel/alderlake
 
 		device ref xhci on
 			register "usb2_ports" = "{
-				[2] = USB2_PORT_MID(OC_SKIP),		/* J_TYPEC1 (USB 3.1 Gen2) */
-				[4] = USB2_PORT_MID(OC_SKIP),		/* Type-A (USB 3.1 Gen2) */
-				[5] = USB2_PORT_MID(OC_SKIP),		/* J_TYPEC2 (USB 3.1 Gen2) */
-				[6] = USB2_PORT_MID(OC_SKIP),		/* Finger */
+				[2] = USB2_PORT_MID(OC_SKIP),		/* Type-C 3.2 Gen 2 (C1) */
+				[4] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 1 (Left) */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* Type-C 3.2 Gen 2 (C2) */
+				[6] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[8] = USB2_PORT_MID(OC_SKIP),		/* Type-A */
+				[8] = USB2_PORT_MID(OC_SKIP),		/* Type-A 2.0 (Left) */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A (USB 3.1 Gen2) */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC2 */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 (Left) */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (C2) */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (C1) */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (C1) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 5""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 6""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 9""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/gaze20/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/gaze20/overridetree.cb
@@ -20,19 +20,73 @@ chip soc/intel/alderlake
 
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* USB Type-C */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* USB 2.0 Type-A audio board */
-				[2] = USB2_PORT_MID(OC_SKIP),		/* USB 3.0 Type-A motherboard */
-				[3] = USB2_PORT_MID(OC_SKIP),		/* USB 3.0 Type-A audio board */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-C 3.2 Gen 2 (Right) */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 2.0 (Left) */
+				[2] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Right) */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 1 (Left) */
 				[5] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB Type-C */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.0 Type-A motherboard */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.0 Type-A audio board */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (Right) */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Right) */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 (Left) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 4""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/lemp12/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/lemp12/overridetree.cb
@@ -16,18 +16,67 @@ chip soc/intel/alderlake
 		device ref tcss_dma0 on end
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A Left */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A Right */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 */
-				[3] = USB2_PORT_MID(OC_SKIP),		/* 3G/LTE */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Left) */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 1 (Right) */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* WWAN */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A Left */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A Right */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* 3G/LTE */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Left) */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 (Right) */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* WWAN */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/oryp11/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/oryp11/overridetree.cb
@@ -11,20 +11,79 @@ chip soc/intel/alderlake
 		device ref tcss_dma0 on end
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* AJ_USB1: USB-A 3.2 Gen 1 (Left) */
-				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1: USB-C Thunderbolt (Right) */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC2: USB-C 3.2 Gen 2 (Back) */
-				[4] = USB2_PORT_MID(OC_SKIP),		/* Per-key RGB */
-				[5] = USB2_PORT_MID(OC_SKIP),		/* J_USB1: USB-A 3.2 Gen 1 (Right) */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 1 (Left) */
+				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt (Right) */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.2 Gen 2 (Back) */
+				[4] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 1 (Right) */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* AJ_USB1: USB-A 3.2 Gen 1 (Left) */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB1: USB-A 3.2 Gen 1 (Right) */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC2: USB-C 3.2 Gen 2 (Back) */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC2: USB-C 3.2 Gen 2 (Back) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 (Left) */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 (Right) */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (Back) */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (Back) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 KBLED""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 6""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/oryp12/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/oryp12/overridetree.cb
@@ -9,18 +9,67 @@ chip soc/intel/alderlake
 
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		// J_AUD1
-				[2] = USB2_PORT_MID(OC_SKIP),		// J_TYPEC2
-				[5] = USB2_PORT_MID(OC_SKIP),		// J_USB1
+				[0] = USB2_PORT_MID(OC_SKIP),		// Type-A 3.2 Gen 1
+				[2] = USB2_PORT_MID(OC_SKIP),		// Type-C 3.2 Gen 2
+				[5] = USB2_PORT_MID(OC_SKIP),		// Type-A 3.2 Gen 1
 				[7] = USB2_PORT_MID(OC_SKIP),		// Camera
-				[8] = USB2_PORT_MID(OC_SKIP),		// J_TYPEC1 (TBT)
+				[8] = USB2_PORT_MID(OC_SKIP),		// Thunderbolt
 				[13] = USB2_PORT_MID(OC_SKIP),		// Bluetooth
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	// J_AUD1
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	// J_USB1
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	// J_TYPEC2
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	// Type-A 3.2 Gen 1
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	// Type-A 3.2 Gen 1
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	// Type-C 3.2 Gen 2
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 6""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/rpl/variants/serw13/overridetree.cb
+++ b/src/mainboard/system76/rpl/variants/serw13/overridetree.cb
@@ -9,20 +9,79 @@ chip soc/intel/alderlake
 
 		device ref xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* TYPEC2 (USB 3.1 Gen2 + DP 1.4 HBR3) */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* AJ_USB1 (USB 3.2 Gen2) */
-				[2] = USB2_PORT_MID(OC_SKIP),		/* AJ_USB2 (USB 3.2 Gen2 + charger) */
-				[5] = USB2_PORT_MID(OC_SKIP),		/* Per-KB */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-C 3.1 Gen 2 + DP 1.4 HBR3 */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 */
+				[2] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen2 + charger */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[8] = USB2_PORT_MID(OC_SKIP),		/* TBT USB2.0 */
+				[8] = USB2_PORT_MID(OC_SKIP),		/* Thunderbolt */
 				[13] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* TYPEC2 (USB 3.1 Gen2 + DP 1.4 HBR3) */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* AJ_USB1 (USB 3.2 Gen2) */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* AJ_USB2 (USB 3.2 Gen2 + charger) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.1 Gen 2 + DP 1.4 HBR3 */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 + charger */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 KBLED""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port3 on end
+					end
+				end
+			end
 		end
 
 		device ref i2c0 on

--- a/src/mainboard/system76/tgl-h/variants/gaze16-3050/overridetree.cb
+++ b/src/mainboard/system76/tgl-h/variants/gaze16-3050/overridetree.cb
@@ -29,20 +29,79 @@ chip soc/intel/tigerlake
 		end
 		device ref south_xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Gen 1 (Right) */
-				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* USB 3.2 Gen 2 Type C (Right) */
-				[3] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Gen 1 (Left) */
-				[4] = USB2_PORT_MID(OC_SKIP),		/* USB 2.0 (Left) */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* J_USB1: Type-A 3.2 Gen 2 (Right) */
+				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 (Right) */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* AJ_USB2/RJ_USB1: Type-A 3.2 Gen 1 (Left) */
+				[4] = USB2_PORT_MID(OC_SKIP),		/* AJ_USB1/RJ_USB2: Type-A 2.0 (Left) */
 				[5] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[13] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 2 (Right) */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 2 Type C (Right) */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 2 Type C (Right) */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 1 (Left) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB1: Type-A 3.2 Gen 2 (Right) */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 (Right) (CC1) */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 (Right) (CC2) */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* AJ_USB1/RJ_USB2: Type-A 3.2 Gen 1 (Left) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 4""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 5""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 		device ref sata on
 			register "SataPortsEnable" = "{

--- a/src/mainboard/system76/tgl-h/variants/gaze16-3060/overridetree.cb
+++ b/src/mainboard/system76/tgl-h/variants/gaze16-3060/overridetree.cb
@@ -29,20 +29,79 @@ chip soc/intel/tigerlake
 		end
 		device ref south_xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Gen 2 (Right) */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Gen 1 (Left) */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* USB 3.2 Gen 2 Type C (Back) */
-				[5] = USB2_PORT_MID(OC_SKIP),		/* USB 2.0 (Left) */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 2 (Right) */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.2 Gen 1 (Left) */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.2 Gen 2 (Back) */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* Type-A 2.0 (Left) */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[8] = USB2_PORT_MID(OC_SKIP),		/* Per-Key */
+				[8] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[13] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 2 (Right) */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 1 (Left) */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 2 Type C (Back) */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 2 (Right) */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.2 Gen 1 (Left) */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (Back) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 6""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 KBLED""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+				end
+			end
 		end
 		device ref sata on
 			register "SataPortsEnable" = "{

--- a/src/mainboard/system76/tgl-h/variants/oryp8/overridetree.cb
+++ b/src/mainboard/system76/tgl-h/variants/oryp8/overridetree.cb
@@ -44,9 +44,9 @@ chip soc/intel/tigerlake
 				[0] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Gen 1 (Left) */
 				[2] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Gen 1 (Right 1) */
 				[3] = USB2_PORT_MID(OC_SKIP),		/* USB 3.2 Gen 1 (Right 2) */
-				[4] = USB2_PORT_MID(OC_SKIP),		/* Per-Key */
+				[4] = USB2_PORT_MID(OC_SKIP),		/* KBLED */
 				[7] = USB2_PORT_MID(OC_SKIP),		/* Camera */
-				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* TYPEC1 */
+				[8] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
 				[13] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
@@ -55,6 +55,65 @@ chip soc/intel/tigerlake
 				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 1 (Right 1) */
 				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB 3.2 Gen 1 (Right 2) */
 			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 4""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 KBLED""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Thunderbolt""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port9 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port14 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port4 on end
+					end
+				end
+			end
 		end
 		device ref sata on
 			register "SataPortsEnable[1]" = "1" # SSD2 (SATA1A)

--- a/src/mainboard/system76/tgl-u/variants/darp7/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/darp7/overridetree.cb
@@ -55,11 +55,11 @@ chip soc/intel/tigerlake
 
 		device ref south_xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* UJ_USB1 */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* UJ_USB1: Type-A 2.0 */
 				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 */
 				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1 */
 				[4] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
-				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC2 */
+				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
@@ -69,24 +69,21 @@ chip soc/intel/tigerlake
 				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 CH1 */
 			}"
 
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 UJ_USB1""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_A"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC1""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
-						register "group" = "ACPI_PLD_GROUP(1, 2)"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_1""
+						register "desc" = ""USB2 Port 3""
 						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(1, 1)"
 						device ref usb2_port3 on end
 					end
 					chip drivers/usb/acpi
@@ -95,9 +92,8 @@ chip soc/intel/tigerlake
 						device ref usb2_port5 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC2""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
-						register "group" = "ACPI_PLD_GROUP(1, 3)"
 						device ref usb2_port6 on end
 					end
 					chip drivers/usb/acpi
@@ -111,22 +107,18 @@ chip soc/intel/tigerlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_TYPEC1 CH0""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(1, 2)"
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_1""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(1, 1)"
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port3 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_TYPEC1 CH1""
-						register "type" = "UPC_TYPE_A"
-						# TODO
-						#register "group" = "ACPI_PLD_GROUP(1, 2)"
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port4 on end
 					end
 				end

--- a/src/mainboard/system76/tgl-u/variants/galp5/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/galp5/overridetree.cb
@@ -55,39 +55,35 @@ chip soc/intel/tigerlake
 
 		device ref south_xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_2 */
-				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 */
-				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1 */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_2: Type-A 3.2 Gen 1 */
+				[1] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 */
+				[2] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1: Type-A 3.2 Gen 1 */
 				[4] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
-				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC2 */
+				[5] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_2 */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 CH0 */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1 */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1 CH1 */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_2: Type-A 3.2 Gen 1 */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 CH0 */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1: Type-A 3.2 Gen 1 */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_TYPEC1: Type-C 3.2 Gen 2 CH1 */
 			}"
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_2""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(1, 2)"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC1""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
-						register "group" = "ACPI_PLD_GROUP(2, 1)"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_1""
+						register "desc" = ""USB2 Port 3""
 						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(2, 2)"
 						device ref usb2_port3 on end
 					end
 					chip drivers/usb/acpi
@@ -96,9 +92,8 @@ chip soc/intel/tigerlake
 						device ref usb2_port5 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC2""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
-						register "group" = "ACPI_PLD_GROUP(1, 1)"
 						device ref usb2_port6 on end
 					end
 					chip drivers/usb/acpi
@@ -112,27 +107,23 @@ chip soc/intel/tigerlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_2""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(1, 2)"
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_TYPEC1 CH0""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(2, 1)"
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_1""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(2, 2)"
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port3 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_TYPEC1 CH1""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(2, 1)"
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
 						device ref usb3_port4 on end
 					end
 				end

--- a/src/mainboard/system76/tgl-u/variants/lemp10/overridetree.cb
+++ b/src/mainboard/system76/tgl-u/variants/lemp10/overridetree.cb
@@ -56,36 +56,39 @@ chip soc/intel/tigerlake
 
 		device ref south_xhci on
 			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1 */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_2 */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* J_TYPEC1 */
+				[0] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_1: Type-A 3.2 Gen 2 */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* J_USB3_2: Type-A 3.2 Gen 1 */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Thunderbolt */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* WWAN */
 				[6] = USB2_PORT_MID(OC_SKIP),		/* Camera */
 				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
 			}"
 			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1 */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_2 */
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_1: Type-A 3.2 Gen 2 */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* J_USB3_2: Type-A 3.2 Gen 1 */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* WWAN */
 			}"
-			# ACPI
 			chip drivers/usb/acpi
 				device ref xhci_root_hub on
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_1""
+						register "desc" = ""USB2 Port 1""
 						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(1, 2)"
 						device ref usb2_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_USB3_2""
+						register "desc" = ""USB2 Port 2""
 						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(2, 1)"
 						device ref usb2_port2 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB2 J_TYPEC1""
+						register "desc" = ""USB2 Thunderbolt""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
-						register "group" = "ACPI_PLD_GROUP(1, 1)"
 						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port4 on end
 					end
 					chip drivers/usb/acpi
 						register "desc" = ""USB2 Camera""
@@ -98,16 +101,19 @@ chip soc/intel/tigerlake
 						device ref usb2_port10 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_1""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(1, 1)"
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port1 on end
 					end
 					chip drivers/usb/acpi
-						register "desc" = ""USB3 J_USB3_2""
-						register "type" = "UPC_TYPE_A"
-						register "group" = "ACPI_PLD_GROUP(2, 1)"
+						register "desc" = ""USB3 Port 2""
+						register "type" = "UPC_TYPE_USB3_A"
 						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb3_port4 on end
 					end
 				end
 			end

--- a/src/mainboard/system76/whl-u/devicetree.cb
+++ b/src/mainboard/system76/whl-u/devicetree.cb
@@ -62,24 +62,6 @@ chip soc/intel/cannonlake
 		end
 		device ref dptf		on  end
 		device ref thermal	on  end
-		device ref xhci		on
-			register "usb2_ports" = "{
-				[0] = USB2_PORT_MID(OC_SKIP),		/* USB-A */
-				[1] = USB2_PORT_MID(OC_SKIP),		/* 3G / LTE */
-				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* USB-C */
-				[3] = USB2_PORT_MID(OC_SKIP),		/* USB-A */
-				[6] = USB2_PORT_MAX(OC_SKIP),		/* Camera */
-				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
-			}"
-			register "usb3_ports" = "{
-				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB-A */
-				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* 4G on galp3-c, NC on darp5 */
-				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB-C */
-				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* USB-A */
-				[4] = USB3_PORT_EMPTY,			/* Used by TBT */
-				[5] = USB3_PORT_EMPTY,			/* Used by TBT */
-			}"
-		end
 		device ref cnvi_wifi	on
 			chip drivers/wifi/generic
 				register "wake" = "PME_B0_EN_BIT"

--- a/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
+++ b/src/mainboard/system76/whl-u/variants/darp5/overridetree.cb
@@ -3,6 +3,77 @@
 chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x1325 inherit
+
+		device ref xhci on
+			register "usb2_ports" = "{
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.1 Gen 1 (Right) */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* Type-A 2.0 (Left) */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.2 Gen 2 (Right) */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.1 Gen 1 (Left) */
+				[5] = USB2_PORT_MID(OC_SKIP),		/* Fingerprint */
+				[6] = USB2_PORT_MAX(OC_SKIP),		/* Camera */
+				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
+			}"
+			register "usb3_ports" = "{
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.1 Gen 1 (Right) */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.2 Gen 2 (Right) */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.1 Gen 1 (Left) */
+			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 2""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 4""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port4 on end
+					end
+				end
+			end
+		end
 		device ref i2c0 on
 			chip drivers/i2c/hid
 				register "generic.hid" = ""SYNA1202""

--- a/src/mainboard/system76/whl-u/variants/galp3-c/overridetree.cb
+++ b/src/mainboard/system76/whl-u/variants/galp3-c/overridetree.cb
@@ -3,6 +3,83 @@
 chip soc/intel/cannonlake
 	device domain 0 on
 		subsystemid 0x1558 0x1323 inherit
+
+		device ref xhci on
+			register "usb2_ports" = "{
+				[0] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.1 Gen 1 (Right) */
+				[1] = USB2_PORT_MID(OC_SKIP),		/* WWAN */
+				[2] = USB2_PORT_TYPE_C(OC_SKIP),	/* Type-C 3.1 Gen 2 (Right) */
+				[3] = USB2_PORT_MID(OC_SKIP),		/* Type-A 3.1 Gen 1 (Left) */
+				[5] = USB2_PORT_MAX(OC_SKIP),		/* Fingerprint */
+				[6] = USB2_PORT_MAX(OC_SKIP),		/* Camera */
+				[9] = USB2_PORT_MID(OC_SKIP),		/* Bluetooth */
+			}"
+			register "usb3_ports" = "{
+				[0] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.1 Gen 1 (Right) */
+				[1] = USB3_PORT_DEFAULT(OC_SKIP),	/* WWAN */
+				[2] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-C 3.1 Gen 2 (Right) */
+				[3] = USB3_PORT_DEFAULT(OC_SKIP),	/* Type-A 3.1 Gen 1 (Left) */
+			}"
+			chip drivers/usb/acpi
+				device ref xhci_root_hub on
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 1""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb2_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Port 4""
+						register "type" = "UPC_TYPE_A"
+						device ref usb2_port4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Fingerprint""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port7 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB2 Bluetooth""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb2_port10 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 WWAN""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device ref usb3_port2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 3""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						device ref usb3_port3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB3 Port 4""
+						register "type" = "UPC_TYPE_USB3_A"
+						device ref usb3_port4 on end
+					end
+				end
+			end
+		end
 		device ref i2c0 on
 			# I2C HID not supported on galp3-c
 		end


### PR DESCRIPTION
upstream: [CB:94134](https://review.coreboot.org/c/coreboot/+/94134)

Inclusion of these has been requested for newer models, so I've gone through and added them for existing models.

Initial pass for adding/fixing xHCI ACPI configs.

- Normalize descriptions using simple names
- Fix connector types

PLD info is not added to save time of having to go through every board schematic to figure out where the port is.